### PR TITLE
Resolve dependabot errors

### DIFF
--- a/cmd/sdkr/build.go
+++ b/cmd/sdkr/build.go
@@ -80,7 +80,7 @@ var buildCmd = &cobra.Command{
 		}
 
 		if _, err := os.Stat(configs.DockerfilePath); os.IsNotExist(err) {
-			return fmt.Errorf(color.RedString("Dockerfile not found at %s", configs.DockerfilePath))
+			return errors.New(color.RedString("Dockerfile not found at %s", configs.DockerfilePath))
 		}
 
 		// In the RunE function, when creating the opts
@@ -97,7 +97,7 @@ var buildCmd = &cobra.Command{
 
 		err := docker.Build(imageName, tag, opts)
 		if err != nil {
-			return fmt.Errorf(color.RedString("Docker build failed: %v", err))
+			return errors.New(color.RedString("Docker build failed: %v", err))
 		}
 		return nil
 	},
@@ -110,14 +110,14 @@ smurf sdkr build
 }
 
 func init() {
-    buildCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "Path to Dockerfile relative to context directory")
-    buildCmd.Flags().StringVar(&configs.ContextDir, "context", "", "Build context directory (default: current directory)")
-    buildCmd.Flags().BoolVar(&configs.NoCache, "no-cache", false, "Do not use cache when building the image")
-    buildCmd.Flags().StringArrayVar(&configs.BuildArgs, "build-arg", []string{}, "Set build-time variables")
-    buildCmd.Flags().StringVar(&configs.Target, "target", "", "Set the target build stage to build")
-    buildCmd.Flags().StringVar(&configs.Platform, "platform", "", "Set the platform for the build (e.g., linux/amd64, linux/arm64)")
-    buildCmd.Flags().IntVar(&configs.BuildTimeout, "timeout", 1500, "Set the build timeout")
-    buildCmd.Flags().BoolVar(&configs.BuildKit, "buildkit", false, "Enable BuildKit for advanced Dockerfile features")
+	buildCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "Path to Dockerfile relative to context directory")
+	buildCmd.Flags().StringVar(&configs.ContextDir, "context", "", "Build context directory (default: current directory)")
+	buildCmd.Flags().BoolVar(&configs.NoCache, "no-cache", false, "Do not use cache when building the image")
+	buildCmd.Flags().StringArrayVar(&configs.BuildArgs, "build-arg", []string{}, "Set build-time variables")
+	buildCmd.Flags().StringVar(&configs.Target, "target", "", "Set the target build stage to build")
+	buildCmd.Flags().StringVar(&configs.Platform, "platform", "", "Set the platform for the build (e.g., linux/amd64, linux/arm64)")
+	buildCmd.Flags().IntVar(&configs.BuildTimeout, "timeout", 1500, "Set the build timeout")
+	buildCmd.Flags().BoolVar(&configs.BuildKit, "buildkit", false, "Enable BuildKit for advanced Dockerfile features")
 
-    sdkrCmd.AddCommand(buildCmd)
+	sdkrCmd.AddCommand(buildCmd)
 }

--- a/cmd/sdkr/provisionHub.go
+++ b/cmd/sdkr/provisionHub.go
@@ -124,7 +124,7 @@ Set DOCKER_USERNAME and DOCKER_PASSWORD environment variables for Docker Hub aut
 		}
 
 		if scanErr != nil {
-			return fmt.Errorf("Docker Hub provisioning failed due to previous errors")
+			return fmt.Errorf("%v", "Docker Hub provisioning failed due to previous errors")
 		}
 
 		if !configs.ConfirmAfterPush {

--- a/cmd/sdkr/tag.go
+++ b/cmd/sdkr/tag.go
@@ -1,6 +1,7 @@
 package sdkr
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/clouddrove/smurf/configs"
@@ -42,7 +43,7 @@ var tagCmd = &cobra.Command{
 			}
 
 			if source == "" || target == "" {
-				return fmt.Errorf(color.RedString("both SOURCE and TARGET must be provided either as arguments or in the config"))
+				return errors.New(color.RedString("both SOURCE and TARGET must be provided either as arguments or in the config"))
 			}
 		}
 
@@ -52,7 +53,7 @@ var tagCmd = &cobra.Command{
 			Target: target,
 		}
 		if err := docker.TagImage(opts); err != nil {
-			return fmt.Errorf(color.RedString("failed to tag image: %v", err))
+			return errors.New(color.RedString("failed to tag image: %v", err))
 		}
 		pterm.Success.Printf("Successfully tagged image from %q to %q.\n", source, target)
 		return nil

--- a/cmd/selm/create.go
+++ b/cmd/selm/create.go
@@ -44,7 +44,7 @@ var createChartCmd = &cobra.Command{
 
 		err := helm.CreateChart(name, configs.Directory)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("failed to create Helm chart: %v", err))
+			return errors.New(color.RedString("failed to create Helm chart: %v", err))
 		}
 		return nil
 	},

--- a/cmd/selm/lint.go
+++ b/cmd/selm/lint.go
@@ -38,7 +38,7 @@ var lintCmd = &cobra.Command{
 
 		err := helm.HelmLint(chartPath, configs.File)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm lint failed: %v", err))
+			return errors.New(color.RedString("Helm lint failed: %v", err))
 		}
 		return nil
 	},

--- a/cmd/selm/provision.go
+++ b/cmd/selm/provision.go
@@ -65,7 +65,7 @@ var provisionCmd = &cobra.Command{
 
 		err := helm.HelmProvision(releaseName, chartPath, configs.Namespace)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm provision failed: %v", err))
+			return errors.New(color.RedString("Helm provision failed: %v", err))
 		}
 		return nil
 	},

--- a/cmd/selm/rollback.go
+++ b/cmd/selm/rollback.go
@@ -92,7 +92,7 @@ The first argument is the name of the release to roll back, and the second is th
 
 		err := helm.HelmRollback(releaseName, revision, rollbackOpts)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm rollback failed: %v", err))
+			return errors.New(color.RedString("Helm rollback failed: %v", err))
 		}
 		pterm.Success.Println(fmt.Sprintf("Successfully rolled back release '%s' to revision '%d'", releaseName, revision))
 		return nil

--- a/cmd/selm/status.go
+++ b/cmd/selm/status.go
@@ -52,7 +52,7 @@ var statusCmd = &cobra.Command{
 
 		err := helm.HelmStatus(releaseName, configs.Namespace)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm status failed: %v", err))
+			return errors.New(color.RedString("Helm status failed: %v", err))
 		}
 		return nil
 	},

--- a/cmd/selm/template.go
+++ b/cmd/selm/template.go
@@ -59,7 +59,7 @@ var templateCmd = &cobra.Command{
 
 		err := helm.HelmTemplate(releaseName, chartPath, configs.Namespace, repoURL, configs.File)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm template failed: %v", err))
+			return errors.New(color.RedString("Helm template failed: %v", err))
 		}
 		return nil
 	},

--- a/cmd/selm/uninstall.go
+++ b/cmd/selm/uninstall.go
@@ -52,7 +52,7 @@ var uninstallCmd = &cobra.Command{
 
 		err := helm.HelmUninstall(releaseName, configs.Namespace)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm uninstall failed: %v", err))
+			return errors.New(color.RedString("Helm uninstall failed: %v", err))
 		}
 		return nil
 	},

--- a/cmd/selm/upgrade.go
+++ b/cmd/selm/upgrade.go
@@ -75,7 +75,7 @@ var upgradeCmd = &cobra.Command{
 			}
 			if !exists {
 				if err := helm.HelmInstall(releaseName, chartPath, configs.Namespace, configs.File, timeoutDuration, configs.Atomic, configs.Debug, configs.Set, []string{}, RepoURL, Version); err != nil {
-					return fmt.Errorf("%v", color.RedString("Helm install failed: %v", err))
+					return errors.New(color.RedString("Helm install failed: %v", err))
 				}
 			}
 		}
@@ -99,7 +99,7 @@ var upgradeCmd = &cobra.Command{
 			Version,
 		)
 		if err != nil {
-			return fmt.Errorf("%v", color.RedString("Helm upgrade failed: %v", err))
+			return errors.New(color.RedString("Helm upgrade failed: %v", err))
 		}
 		pterm.Success.Println("Helm chart upgraded successfully.")
 		return nil

--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,7 +36,7 @@ func Build(imageName, tag string, opts BuildOptions) error {
 	)
 	if err != nil {
 		spinner.Fail()
-		return fmt.Errorf(color.RedString("docker client init failed: %v", err))
+		return errors.New(color.RedString("docker client init failed: %v", err))
 	}
 	defer cli.Close()
 
@@ -44,13 +45,13 @@ func Build(imageName, tag string, opts BuildOptions) error {
 	})
 	if err != nil {
 		spinner.Fail()
-		return fmt.Errorf(color.RedString("context creation failed: %v", err))
+		return errors.New(color.RedString("context creation failed: %v", err))
 	}
 	defer buildCtx.Close()
 
 	relDockerfilePath, err := filepath.Rel(opts.ContextDir, opts.DockerfilePath)
 	if err != nil {
-		return fmt.Errorf(color.RedString("invalid dockerfile path: %v", err))
+		return errors.New(color.RedString("invalid dockerfile path: %v", err))
 	}
 
 	buildArgsPtr := make(map[string]*string)
@@ -63,7 +64,7 @@ func Build(imageName, tag string, opts BuildOptions) error {
 	if platform != "" {
 		parts := strings.Split(platform, "/")
 		if len(parts) != 2 {
-			return fmt.Errorf(color.RedString("invalid platform format. Expected os/arch, got: %s", platform))
+			return errors.New(color.RedString("invalid platform format. Expected os/arch, got: %s", platform))
 		}
 	}
 
@@ -95,120 +96,120 @@ func Build(imageName, tag string, opts BuildOptions) error {
 
 	// Build function modification
 
-// Modify this part in your docker.Build function
-if opts.BuildKit {
-    spinner.UpdateText("Running build with BuildKit enabled...")
-    
-    // Construct docker command arguments
-    args := []string{"build"}
-    
-    // Add the tag
-    args = append(args, "--tag", fullImageName)
-    
-    // Add other build options
-    if opts.NoCache {
-        args = append(args, "--no-cache")
-    }
-    if relDockerfilePath != "" {
-        args = append(args, "--file", relDockerfilePath)
-    }
-    for k, v := range opts.BuildArgs {
-        args = append(args, "--build-arg", fmt.Sprintf("%s=%s", k, v))
-    }
-    if opts.Target != "" {
-        args = append(args, "--target", opts.Target)
-    }
-    if platform != "" {
-        args = append(args, "--platform", platform)
-    }
-    
-    // Add the context directory as the last argument
-    args = append(args, opts.ContextDir)
-    
-    // Create and configure the command
-    cmd := exec.Command("docker", args...)
-    
-    // Set environment with BuildKit enabled
-    cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
-    
-    // Create pipes for stdout and stderr
-    stdoutPipe, err := cmd.StdoutPipe()
-    if err != nil {
-        return fmt.Errorf(color.RedString("failed to create stdout pipe: %v", err))
-    }
-    stderrPipe, err := cmd.StderrPipe()
-    if err != nil {
-        return fmt.Errorf(color.RedString("failed to create stderr pipe: %v", err))
-    }
-    
-    // Start the command
-    if err := cmd.Start(); err != nil {
-        return fmt.Errorf(color.RedString("failed to start build: %v", err))
-    }
-    
-    spinner.Success()
-    progressBar, _ := pterm.DefaultProgressbar.WithTotal(100).WithTitle("Building").Start()
-    
-    // Process stdout
-    go func() {
-        scanner := bufio.NewScanner(stdoutPipe)
-        for scanner.Scan() {
-            line := scanner.Text()
-            if strings.HasPrefix(line, "Step ") {
-                pterm.Info.Println(color.CyanString(line))
-                progressBar.Add(5)
-            } else {
-                trimmed := strings.TrimSpace(line)
-                if trimmed != "" {
-                    pterm.Debug.Println(trimmed)
-                }
-            }
-        }
-    }()
-    
-    // Process stderr
-    go func() {
-        scanner := bufio.NewScanner(stderrPipe)
-        for scanner.Scan() {
-            line := scanner.Text()
-            pterm.Debug.Println(color.YellowString(line))
-        }
-    }()
-    
-    // Wait for the command to complete
-    if err := cmd.Wait(); err != nil {
-        progressBar.Stop()
-        return fmt.Errorf(color.RedString("BuildKit build failed: %v", err))
-    }
-    
-    progressBar.Add(100 - progressBar.Current)
-    
-    time.Sleep(2 * time.Second)
-    
-    inspect, _, err := cli.ImageInspectWithRaw(ctx, fullImageName)
-    if err != nil {
-        return fmt.Errorf(color.RedString("failed to get image info: %v", err))
-    }
-    
-    panel := pterm.DefaultBox.WithTitle("Build Complete").Sprintf(` %s %s %s %s %s %s %s `,
-        color.GreenString("✓ Image Built Successfully"),
-        color.CyanString("Image: %s", fullImageName),
-        color.CyanString("ID: %s", inspect.ID[:12]),
-        color.CyanString("Size: %.2f MB", float64(inspect.Size)/1024/1024),
-        color.CyanString("Platform: %s/%s", inspect.Os, inspect.Architecture),
-        color.CyanString("Created: %s", inspect.Created[:19]),
-        color.CyanString("Layers: %d", len(inspect.RootFS.Layers)),
-    )
-    
-    fmt.Println(panel)
-    return nil
-}
+	// Modify this part in your docker.Build function
+	if opts.BuildKit {
+		spinner.UpdateText("Running build with BuildKit enabled...")
 
-// The rest of your original Build function continues below for non-BuildKit builds
+		// Construct docker command arguments
+		args := []string{"build"}
+
+		// Add the tag
+		args = append(args, "--tag", fullImageName)
+
+		// Add other build options
+		if opts.NoCache {
+			args = append(args, "--no-cache")
+		}
+		if relDockerfilePath != "" {
+			args = append(args, "--file", relDockerfilePath)
+		}
+		for k, v := range opts.BuildArgs {
+			args = append(args, "--build-arg", fmt.Sprintf("%s=%s", k, v))
+		}
+		if opts.Target != "" {
+			args = append(args, "--target", opts.Target)
+		}
+		if platform != "" {
+			args = append(args, "--platform", platform)
+		}
+
+		// Add the context directory as the last argument
+		args = append(args, opts.ContextDir)
+
+		// Create and configure the command
+		cmd := exec.Command("docker", args...)
+
+		// Set environment with BuildKit enabled
+		cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+
+		// Create pipes for stdout and stderr
+		stdoutPipe, err := cmd.StdoutPipe()
+		if err != nil {
+			return errors.New(color.RedString("failed to create stdout pipe: %v", err))
+		}
+		stderrPipe, err := cmd.StderrPipe()
+		if err != nil {
+			return errors.New(color.RedString("failed to create stderr pipe: %v", err))
+		}
+
+		// Start the command
+		if err := cmd.Start(); err != nil {
+			return errors.New(color.RedString("failed to start build: %v", err))
+		}
+
+		spinner.Success()
+		progressBar, _ := pterm.DefaultProgressbar.WithTotal(100).WithTitle("Building").Start()
+
+		// Process stdout
+		go func() {
+			scanner := bufio.NewScanner(stdoutPipe)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.HasPrefix(line, "Step ") {
+					pterm.Info.Println(color.CyanString(line))
+					progressBar.Add(5)
+				} else {
+					trimmed := strings.TrimSpace(line)
+					if trimmed != "" {
+						pterm.Debug.Println(trimmed)
+					}
+				}
+			}
+		}()
+
+		// Process stderr
+		go func() {
+			scanner := bufio.NewScanner(stderrPipe)
+			for scanner.Scan() {
+				line := scanner.Text()
+				pterm.Debug.Println(color.YellowString(line))
+			}
+		}()
+
+		// Wait for the command to complete
+		if err := cmd.Wait(); err != nil {
+			progressBar.Stop()
+			return errors.New(color.RedString("BuildKit build failed: %v", err))
+		}
+
+		progressBar.Add(100 - progressBar.Current)
+
+		time.Sleep(2 * time.Second)
+
+		inspect, _, err := cli.ImageInspectWithRaw(ctx, fullImageName)
+		if err != nil {
+			return errors.New(color.RedString("failed to get image info: %v", err))
+		}
+
+		panel := pterm.DefaultBox.WithTitle("Build Complete").Sprintf(` %s %s %s %s %s %s %s `,
+			color.GreenString("✓ Image Built Successfully"),
+			color.CyanString("Image: %s", fullImageName),
+			color.CyanString("ID: %s", inspect.ID[:12]),
+			color.CyanString("Size: %.2f MB", float64(inspect.Size)/1024/1024),
+			color.CyanString("Platform: %s/%s", inspect.Os, inspect.Architecture),
+			color.CyanString("Created: %s", inspect.Created[:19]),
+			color.CyanString("Layers: %d", len(inspect.RootFS.Layers)),
+		)
+
+		fmt.Println(panel)
+		return nil
+	}
+
+	// The rest of your original Build function continues below for non-BuildKit builds
 	resp, err := cli.ImageBuild(ctx, buildCtx, buildOptions)
 	if err != nil {
 		spinner.Fail()
-		return fmt.Errorf(color.RedString("build failed: %v", err))
+		return errors.New(color.RedString("build failed: %v", err))
 	}
 	defer resp.Body.Close()
 
@@ -229,7 +230,7 @@ if opts.BuildKit {
 
 		if msg.Error != nil {
 			progressBar.Stop()
-			return fmt.Errorf(color.RedString("build error: %v", msg.Error))
+			return errors.New(color.RedString("build error: %v", msg.Error))
 		}
 
 		if msg.Stream != "" {
@@ -252,7 +253,7 @@ if opts.BuildKit {
 
 	if lastError != nil {
 		progressBar.Stop()
-		return fmt.Errorf(color.RedString("build process error: %v", lastError))
+		return errors.New(color.RedString("build process error: %v", lastError))
 	}
 
 	progressBar.Add(100 - progressBar.Current)
@@ -261,7 +262,7 @@ if opts.BuildKit {
 
 	inspect, _, err := cli.ImageInspectWithRaw(ctx, fullImageName)
 	if err != nil {
-		return fmt.Errorf(color.RedString("failed to get image info: %v", err))
+		return errors.New(color.RedString("failed to get image info: %v", err))
 	}
 
 	panel := pterm.DefaultBox.WithTitle("Build Complete").Sprintf(` %s %s %s %s %s %s %s `,

--- a/internal/terraform/drift.go
+++ b/internal/terraform/drift.go
@@ -42,7 +42,7 @@ func DetectDrift(dir string) error {
 	if len(plan.ResourceChanges) > 0 {
 		pterm.Warning.Println("Drift detected:")
 		for _, change := range plan.ResourceChanges {
-			pterm.Printf(color.YellowString("- %s: %s\n", change.Address, change.Change.Actions))
+			pterm.Print(color.YellowString("- %s: %s\n", change.Address, change.Change.Actions))
 		}
 	} else {
 		pterm.Success.Println("No drift detected.")

--- a/internal/terraform/validate.go
+++ b/internal/terraform/validate.go
@@ -63,7 +63,7 @@ func (cv *CustomValidator) formatValidationError(err ValidationError) string {
 // ValidateWithDetails performs validation and returns detailed error output
 func (cv *CustomValidator) ValidateWithDetails(ctx context.Context) error {
 	if cv.tf == nil {
-		return fmt.Errorf("Terraform instance is nil")
+		return fmt.Errorf("%v", "Terraform instance is nil")
 	}
 
 	spinner, _ := pterm.DefaultSpinner.Start("Validating Terraform configuration...")
@@ -149,7 +149,7 @@ func Validate(dir string) error {
 	}
 
 	if tf == nil {
-		return fmt.Errorf("Terraform instance is nil")
+		return fmt.Errorf("%v", "Terraform instance is nil")
 	}
 
 	validator := NewCustomValidator(tf)


### PR DESCRIPTION
Fix go vet warning by using constant format strings in fmt.Errorf and pterm.Printf calls.