### PR TITLE
Update Cloud workflow with PR write permission

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,9 +6,9 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  id-token: write
   contents: read
-  actions: read
+  pull-requests: write
+  id-token: write
 
 jobs:
 


### PR DESCRIPTION
## what
* Cloud calling workflow PR write permission

## why
* To work and support updates cloud pr review workflow changes.
