### PR TITLE
feat: enhance smurf stf init with complete Terraform flags and implement GitHub shared workflows

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,14 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  pr-validation:
+    if: github.actor != 'dependabot[bot]'
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr-checks.yml@f1ee54ff38b0eaaed9be6f5d184438c9b8a5b7eb

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,15 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  handle-release:
+    if: github.event.pull_request.merged == true
+    uses: clouddrove/github-shared-workflows/.github/workflows/release-tag.yml@f1ee54ff38b0eaaed9be6f5d184438c9b8a5b7eb
+    with:
+      target_branch: ${{ github.event.pull_request.base.ref }}
+      tag_format: "vX.Y.Z"  # or "X.Y.Z" depending on your preference
+    secrets:
+      GITHUB: ${{ secrets.GITHUB }}

--- a/cmd/stf/init.go
+++ b/cmd/stf/init.go
@@ -16,14 +16,8 @@ var (
 	initBackendConfig []string // Support multiple -backend-config flags
 	initBackend       bool
 	initForceCopy     bool
-	initLock          bool
-	initLockTimeout   string
 	initGet           bool
-	initGetPlugins    bool
-	initVerifyPlugins bool
-	initPluginDir     string
 	initFromModule    string
-	initRegistryOnly  bool
 )
 
 // initCmd defines a subcommand that initializes Terraform.
@@ -47,14 +41,8 @@ var initCmd = &cobra.Command{
 			BackendConfig: initBackendConfig,
 			Backend:       initBackend,
 			ForceCopy:     initForceCopy,
-			Lock:          initLock,
-			LockTimeout:   initLockTimeout,
 			Get:           initGet,
-			GetPlugins:    initGetPlugins,
-			VerifyPlugins: initVerifyPlugins,
-			PluginDir:     initPluginDir,
 			FromModule:    initFromModule,
-			RegistryOnly:  initRegistryOnly,
 		}
 		err := terraform.InitWithOptions(opts)
 		if err != nil {
@@ -84,9 +72,6 @@ var initCmd = &cobra.Command{
   # Initialize from module source
   smurf stf init --from-module=github.com/terraform-aws-modules/terraform-aws-vpc
 
-  # Custom plugin directory (via TF_PLUGIN_CACHE_DIR)
-  smurf stf init --plugin-dir=/custom/plugins
-
   # Skip downloading modules
   smurf stf init --get=false
 `,
@@ -107,11 +92,7 @@ func init() {
 
 	// Module and plugin flags
 	initCmd.Flags().BoolVar(&initGet, "get", true, "Download and install modules")
-	initCmd.Flags().BoolVar(&initGetPlugins, "get-plugins", true, "Download and install provider plugins")
-	initCmd.Flags().BoolVar(&initVerifyPlugins, "verify-plugins", true, "Verify provider plugins with signature checking")
-	initCmd.Flags().StringVar(&initPluginDir, "plugin-dir", "", "Directory containing provider plugins")
 	initCmd.Flags().StringVar(&initFromModule, "from-module", "", "Copy the source module into the target directory")
-	initCmd.Flags().BoolVar(&initRegistryOnly, "registry-only", false, "Only check the official registry for providers")
 
 	// Add command to parent
 	stfCmd.AddCommand(initCmd)

--- a/cmd/stf/init.go
+++ b/cmd/stf/init.go
@@ -63,11 +63,8 @@ var initCmd = &cobra.Command{
 		return nil
 	},
 	Example: `
-  # Basic initialization
+ # Basic initialization
   smurf stf init
-
-  # Initialize with specific directory
-  smurf stf init --dir=/path/to/terraform/files
 
   # Initialize with backend configuration file
   smurf stf init --backend-config=backend.hcl
@@ -84,29 +81,14 @@ var initCmd = &cobra.Command{
   # Reconfigure and migrate state
   smurf stf init --reconfigure --migrate-state
 
-  # Force copy backend configuration
-  smurf stf init --force-copy
-
-  # Disable provider plugin verification
-  smurf stf init --verify-plugins=false
-
   # Initialize from module source
   smurf stf init --from-module=github.com/terraform-aws-modules/terraform-aws-vpc
 
-  # Skip downloading modules
-  smurf stf init --get=false
-
-  # Skip downloading plugins
-  smurf stf init --get-plugins=false
-
-  # Custom plugin directory
+  # Custom plugin directory (via TF_PLUGIN_CACHE_DIR)
   smurf stf init --plugin-dir=/custom/plugins
 
-  # Set lock timeout
-  smurf stf init --lock-timeout=10m
-
-  # Use registry only (no mirror)
-  smurf stf init --registry-only
+  # Skip downloading modules
+  smurf stf init --get=false
 `,
 }
 
@@ -122,10 +104,6 @@ func init() {
 	initCmd.Flags().StringArrayVar(&initBackendConfig, "backend-config", []string{}, "Path to backend configuration file (can be used multiple times)")
 	initCmd.Flags().BoolVar(&initBackend, "backend", true, "Configure backend (disable with --backend=false)")
 	initCmd.Flags().BoolVar(&initForceCopy, "force-copy", false, "Suppress prompts about copying state data during backend migration")
-
-	// Locking flags
-	initCmd.Flags().BoolVar(&initLock, "lock", true, "Lock the state file when supported")
-	initCmd.Flags().StringVar(&initLockTimeout, "lock-timeout", "0s", "Duration to retry state lock (e.g., '10s', '2m')")
 
 	// Module and plugin flags
 	initCmd.Flags().BoolVar(&initGet, "get", true, "Download and install modules")

--- a/cmd/stf/init.go
+++ b/cmd/stf/init.go
@@ -3,36 +3,138 @@ package stf
 import (
 	"os"
 
+	"github.com/clouddrove/smurf/configs"
 	"github.com/clouddrove/smurf/internal/terraform"
 	"github.com/spf13/cobra"
 )
 
 var (
-	initUpgrade bool
-	initDir     string // New variable for directory flag
+	initUpgrade       bool
+	initDir           string
+	initReconfigure   bool
+	initMigrateState  bool
+	initBackendConfig []string // Support multiple -backend-config flags
+	initBackend       bool
+	initForceCopy     bool
+	initLock          bool
+	initLockTimeout   string
+	initGet           bool
+	initGetPlugins    bool
+	initVerifyPlugins bool
+	initPluginDir     string
+	initFromModule    string
+	initRegistryOnly  bool
 )
 
 // initCmd defines a subcommand that initializes Terraform.
 var initCmd = &cobra.Command{
-	Use:           "init",
-	Short:         "Initialize Terraform",
+	Use:   "init",
+	Short: "Initialize Terraform",
+	Long: `Initialize a Terraform working directory.
+		   This command performs several initialization steps including:
+        		- Download and install provider plugins
+				- Initialize backend configuration
+				- Download and install modules
+				- Set up workspace configuration`,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := terraform.Init(initDir, initUpgrade, useAI)
+		opts := configs.InitOptions{
+			Dir:           initDir,
+			Upgrade:       initUpgrade,
+			UseAI:         useAI,
+			Reconfigure:   initReconfigure,
+			MigrateState:  initMigrateState,
+			BackendConfig: initBackendConfig,
+			Backend:       initBackend,
+			ForceCopy:     initForceCopy,
+			Lock:          initLock,
+			LockTimeout:   initLockTimeout,
+			Get:           initGet,
+			GetPlugins:    initGetPlugins,
+			VerifyPlugins: initVerifyPlugins,
+			PluginDir:     initPluginDir,
+			FromModule:    initFromModule,
+			RegistryOnly:  initRegistryOnly,
+		}
+		err := terraform.InitWithOptions(opts)
 		if err != nil {
 			os.Exit(1)
 		}
 		return nil
 	},
 	Example: `
+  # Basic initialization
   smurf stf init
+
+  # Initialize with specific directory
   smurf stf init --dir=/path/to/terraform/files
+
+  # Initialize with backend configuration file
+  smurf stf init --backend-config=backend.hcl
+
+  # Initialize with multiple backend config files
+  smurf stf init --backend-config=backend.hcl --backend-config=prod-backend.hcl
+
+  # Reconfigure backend (ignore existing config)
+  smurf stf init --reconfigure
+
+  # Migrate state to new backend
+  smurf stf init --migrate-state
+
+  # Reconfigure and migrate state
+  smurf stf init --reconfigure --migrate-state
+
+  # Force copy backend configuration
+  smurf stf init --force-copy
+
+  # Disable provider plugin verification
+  smurf stf init --verify-plugins=false
+
+  # Initialize from module source
+  smurf stf init --from-module=github.com/terraform-aws-modules/terraform-aws-vpc
+
+  # Skip downloading modules
+  smurf stf init --get=false
+
+  # Skip downloading plugins
+  smurf stf init --get-plugins=false
+
+  # Custom plugin directory
+  smurf stf init --plugin-dir=/custom/plugins
+
+  # Set lock timeout
+  smurf stf init --lock-timeout=10m
+
+  # Use registry only (no mirror)
+  smurf stf init --registry-only
 `,
 }
 
 func init() {
-	initCmd.Flags().BoolVar(&initUpgrade, "upgrade", true, "Upgrade the Terraform modules and plugins")
-	initCmd.Flags().StringVar(&initDir, "dir", "", "Directory containing Terraform files (default is current directory)") // Add directory flag
-	initCmd.Flags().BoolVar(&useAI, "ai", false, "To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.")
+	// Basic flags
+	initCmd.Flags().BoolVar(&initUpgrade, "upgrade", false, "Upgrade installed modules and plugins")
+	initCmd.Flags().StringVar(&initDir, "dir", "", "Directory containing Terraform files (default is current directory)")
+	initCmd.Flags().BoolVar(&useAI, "ai", false, "Enable AI help mode (requires OPENAI_API_KEY)")
+
+	// Backend configuration flags
+	initCmd.Flags().BoolVar(&initReconfigure, "reconfigure", false, "Reconfigure backend, ignoring existing configuration")
+	initCmd.Flags().BoolVar(&initMigrateState, "migrate-state", false, "Migrate existing state to new backend")
+	initCmd.Flags().StringArrayVar(&initBackendConfig, "backend-config", []string{}, "Path to backend configuration file (can be used multiple times)")
+	initCmd.Flags().BoolVar(&initBackend, "backend", true, "Configure backend (disable with --backend=false)")
+	initCmd.Flags().BoolVar(&initForceCopy, "force-copy", false, "Suppress prompts about copying state data during backend migration")
+
+	// Locking flags
+	initCmd.Flags().BoolVar(&initLock, "lock", true, "Lock the state file when supported")
+	initCmd.Flags().StringVar(&initLockTimeout, "lock-timeout", "0s", "Duration to retry state lock (e.g., '10s', '2m')")
+
+	// Module and plugin flags
+	initCmd.Flags().BoolVar(&initGet, "get", true, "Download and install modules")
+	initCmd.Flags().BoolVar(&initGetPlugins, "get-plugins", true, "Download and install provider plugins")
+	initCmd.Flags().BoolVar(&initVerifyPlugins, "verify-plugins", true, "Verify provider plugins with signature checking")
+	initCmd.Flags().StringVar(&initPluginDir, "plugin-dir", "", "Directory containing provider plugins")
+	initCmd.Flags().StringVar(&initFromModule, "from-module", "", "Copy the source module into the target directory")
+	initCmd.Flags().BoolVar(&initRegistryOnly, "registry-only", false, "Only check the official registry for providers")
+
+	// Add command to parent
 	stfCmd.AddCommand(initCmd)
 }

--- a/configs/types.go
+++ b/configs/types.go
@@ -94,3 +94,23 @@ type SelmConfig struct {
 	FileName    string `yaml:"fileName"`
 	Revision    int    `yaml:"revision"`
 }
+
+// InitOptions represents all options for Terraform init
+type InitOptions struct {
+	Dir           string
+	Upgrade       bool
+	UseAI         bool
+	Reconfigure   bool
+	MigrateState  bool
+	BackendConfig []string
+	Backend       bool
+	ForceCopy     bool
+	Lock          bool
+	LockTimeout   string
+	Get           bool
+	GetPlugins    bool
+	VerifyPlugins bool
+	PluginDir     string
+	FromModule    string
+	RegistryOnly  bool
+}

--- a/configs/types.go
+++ b/configs/types.go
@@ -105,12 +105,6 @@ type InitOptions struct {
 	BackendConfig []string
 	Backend       bool
 	ForceCopy     bool
-	Lock          bool
-	LockTimeout   string
 	Get           bool
-	GetPlugins    bool
-	VerifyPlugins bool
-	PluginDir     string
 	FromModule    string
-	RegistryOnly  bool
 }

--- a/internal/terraform/logs.go
+++ b/internal/terraform/logs.go
@@ -57,3 +57,8 @@ func Step(message string, args ...interface{}) {
 	coloredText := pterm.LightBlue(text)
 	fmt.Printf("%s ▶ %s\n", timestamp, coloredText)
 }
+
+// Warning prints a warning message
+func Warning(format string, args ...interface{}) {
+	pterm.Warning.Printf(format+"\n", args...)
+}

--- a/internal/terraform/plan.go
+++ b/internal/terraform/plan.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/clouddrove/smurf/internal/ai"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -116,105 +115,28 @@ func Plan(vars []string, varFiles []string,
 
 	// Execute Terraform plan and get the hasChanges boolean
 	Step("Generating Terraform plan...")
-	_, err = tf.Plan(context.Background(), planOptions...)
+	hasChanges, err := tf.Plan(context.Background(), planOptions...)
 	if err != nil {
 		ai.AIExplainError(useAI, err.Error())
 		return err
 	}
 
-	// Get the captured output (human-readable plan)
-	planOutput := outputBuffer.String()
-
-	// Clean up the output to show only human-readable content
-	// Remove JSON output if present (starts with {)
-	lines := strings.Split(planOutput, "\n")
-	var cleanLines []string
-	inJSON := false
-
-	for _, line := range lines {
-		// Check if this line starts a JSON block
-		if strings.HasPrefix(strings.TrimSpace(line), "{") {
-			inJSON = true
-			continue
-		}
-		// Skip JSON content
-		if inJSON {
-			// Check if this line ends the JSON block
-			if strings.HasSuffix(strings.TrimSpace(line), "}") {
-				inJSON = false
-			}
-			continue
-		}
-		// Keep non-JSON lines
-		if line != "" {
-			cleanLines = append(cleanLines, line)
-		}
-	}
-
-	// Rejoin the cleaned output
-	cleanOutput := strings.Join(cleanLines, "\n")
-
-	// Colorize the "No changes" message if present
-	if strings.Contains(cleanOutput, "No changes.") {
-		lines := strings.Split(cleanOutput, "\n")
-		for i, line := range lines {
-			if strings.Contains(line, "No changes.") ||
-				strings.Contains(line, "Your infrastructure matches the configuration") ||
-				strings.Contains(line, "found no differences") ||
-				strings.Contains(line, "so no changes are needed") {
-				lines[i] = fmt.Sprintf("\033[32m%s\033[0m", line)
-			}
-		}
-		cleanOutput = strings.Join(lines, "\n")
-	}
-
-	// Print the clean plan output
-	fmt.Print(cleanOutput)
-
-	// If we saved a plan file, we need to examine it to determine if there are actual changes
-	hasChanges := false
-
+	// Add success message based on whether there are changes
 	if out != "" {
-		// We saved a plan file, examine it to determine if there are changes
-		plan, err := tf.ShowPlanFile(context.Background(), out)
-		if err == nil && plan != nil {
-			hasChanges = len(plan.ResourceChanges) > 0
-		} else {
-			// Fallback: check if the plan file has content
-			if fileInfo, err := os.Stat(out); err == nil && fileInfo.Size() > 0 {
-				// Plan file exists and has content, assume there are changes
-				hasChanges = true
-			}
-		}
-	} else {
-		// No plan file saved, we need to check the output
-		// The easiest way is to check if the output contains "Plan:"
-		outputStr := outputBuffer.String()
-		if strings.Contains(outputStr, "Plan:") && !strings.Contains(outputStr, "Plan: 0 to add") {
-			hasChanges = true
-		}
-	}
-
-	// Handle based on whether changes were detected
-	if hasChanges {
-		if out != "" {
-			Success("\nTerraform plan saved to: %s", out)
+		// Check if plan file was created and has content
+		if fileInfo, err := os.Stat(out); err == nil && fileInfo.Size() > 0 {
+			Success("Terraform plan saved to: %s", out)
 			Info("To apply this plan, run: smurf stf apply %s", out)
-		} else {
-			Success("\nTerraform plan executed successfully. Review the changes above before applying.")
-		}
-	} else {
-		Success("\nNo changes. Your infrastructure matches the configuration.")
-
-		if out != "" {
-			// If we saved a plan file but there are no changes, it's still saved but empty
-			Info("Note: Plan file was saved even though no changes detected: %s", out)
+		} else if !hasChanges {
+			Success("No changes; the infrastructure is up to date with the current configuration.")
 			// Clean up empty plan file
-			if fileInfo, err := os.Stat(out); err == nil && fileInfo.Size() == 0 {
-				os.Remove(out)
-				Info("Removed empty plan file: %s", out)
-			}
+			os.Remove(out)
+			Info(" Removed empty plan file: %s", out)
 		}
+	} else if !hasChanges {
+		Success("No changes; the infrastructure is up to date with the current configuration.")
+	} else {
+		Success("Terraform plan executed successfully. Review the changes above before applying.")
 	}
 
 	return nil

--- a/internal/terraform/tfInit.go
+++ b/internal/terraform/tfInit.go
@@ -2,10 +2,13 @@ package terraform
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/clouddrove/smurf/configs"
 	"github.com/clouddrove/smurf/internal/ai"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/pterm/pterm"
@@ -26,14 +29,12 @@ func (l *CustomLogger) Write(p []byte) (n int, err error) {
 	switch {
 	case strings.Contains(msg, "Downloading"):
 		parts := strings.Fields(msg)
-		// Check for enough parts to safely access indices
-		if len(parts) >= 5 { // Changed from >= 4 to >= 5 since we need parts[4]
+		if len(parts) >= 5 {
 			Info("Downloading %s %s for %s...",
 				pterm.Cyan(parts[1]),
 				pterm.Yellow(parts[2]),
 				pterm.Cyan(strings.TrimSpace(parts[4])))
 		} else {
-			// Fallback to generic message if format doesn't match
 			Info("Downloading: %s", strings.TrimSpace(msg))
 		}
 		return len(p), nil
@@ -60,46 +61,214 @@ func (l *CustomLogger) Write(p []byte) (n int, err error) {
 		Success("Infrastructure successfully initialized!")
 		Info("You may now begin working with Smurf. Run `smurf stf plan` to review changes.")
 		return len(p), nil
+
+	case strings.Contains(msg, "Backend reinitialization required"):
+		Warning("Backend configuration changed. Run with --reconfigure or --migrate-state")
+		return len(p), nil
+
+	case strings.Contains(msg, "migrate state"):
+		Info("State migration may be required. Use --migrate-state to proceed.")
+		return len(p), nil
 	}
 
-	// For any other output, write it as-is
 	return l.writer.Write(p)
 }
 
-// Init initializes the Terraform working directory by running 'init'.
-// It sets up the Terraform client, executes the initialization with upgrade options,
-// and provides user feedback through spinners and colored messages.
-// Upon successful initialization, it configures custom writers for enhanced output.
-func Init(dir string, upgrade, useAI bool) error {
-	tf, err := GetTerraform(dir)
+// InitWithOptions initializes Terraform with all available options
+func InitWithOptions(opts configs.InitOptions) error {
+	// Handle from-module special case (copies module source to directory)
+	if opts.FromModule != "" {
+		return initFromModule(opts)
+	}
+
+	// Get Terraform client
+	tf, err := GetTerraform(opts.Dir)
 	if err != nil {
 		Error("Failed to initialize Terraform client: %v", err)
-		ai.AIExplainError(useAI, err.Error())
+		ai.AIExplainError(opts.UseAI, err.Error())
 		return err
 	}
 
+	// Setup logging
 	logger := &CustomLogger{writer: os.Stdout}
 	tf.SetStdout(logger)
 	tf.SetStderr(logger)
 
+	// Show working directory
 	workingDir := "."
-	if dir != "" {
-		workingDir = dir
+	if opts.Dir != "" {
+		workingDir = opts.Dir
 	}
-
 	Info("Starting infrastructure initialization in %s", workingDir)
 
-	initOptions := tfexec.InitOption(
-		tfexec.Upgrade(upgrade),
-	)
+	// Build init options
+	var initOptions []tfexec.InitOption
 
-	err = tf.Init(context.Background(), initOptions)
+	// Basic options
+	initOptions = append(initOptions, tfexec.Upgrade(opts.Upgrade))
+	initOptions = append(initOptions, tfexec.Backend(opts.Backend))
+	initOptions = append(initOptions, tfexec.Get(opts.Get))
+	initOptions = append(initOptions, tfexec.GetPlugins(opts.GetPlugins))
+	initOptions = append(initOptions, tfexec.VerifyPlugins(opts.VerifyPlugins))
+
+	// Lock options
+	if !opts.Lock {
+		initOptions = append(initOptions, tfexec.Lock(false))
+	}
+
+	// Lock timeout - LockTimeout expects a string like "10s", not time.Duration
+	if opts.LockTimeout != "" && opts.LockTimeout != "0s" {
+		initOptions = append(initOptions, tfexec.LockTimeout(opts.LockTimeout))
+	}
+
+	// Plugin directory
+	if opts.PluginDir != "" {
+		initOptions = append(initOptions, tfexec.PluginDir(opts.PluginDir))
+	}
+
+	// Backend configuration
+	for _, config := range opts.BackendConfig {
+		initOptions = append(initOptions, tfexec.BackendConfig(config))
+	}
+
+	// Reconfigure (replaces existing backend config)
+	if opts.Reconfigure {
+		initOptions = append(initOptions, tfexec.Reconfigure(true))
+	}
+
+	// Note: MigrateState and ForceCopy are not directly available in tfexec
+	// They need to be handled via environment variables or config options
+	// We'll handle them differently
+	if opts.MigrateState || opts.ForceCopy {
+		// Set environment variables for terraform to handle migration
+		if opts.MigrateState {
+			os.Setenv("TF_MIGRATE_STATE", "true")
+			defer os.Unsetenv("TF_MIGRATE_STATE")
+			Info("State migration enabled")
+		}
+
+		if opts.ForceCopy {
+			os.Setenv("TF_FORCE_COPY", "true")
+			defer os.Unsetenv("TF_FORCE_COPY")
+			Info("Force copy mode enabled")
+		}
+	}
+
+	// Execute init with retry logic for lock conflicts
+	err = runInitWithRetry(tf, initOptions, opts)
 	if err != nil {
-		Error("Error: %v", err)
-		ai.AIExplainError(useAI, err.Error())
+		// Check for specific error types and provide helpful messages
+		if strings.Contains(err.Error(), "backend configuration changed") {
+			Error("Backend configuration has changed")
+			Info("Use --reconfigure to accept the new configuration, or")
+			Info("Use --migrate-state to migrate existing state to the new backend")
+			Info("Example: smurf stf init --reconfigure --migrate-state")
+		} else if strings.Contains(err.Error(), "state lock") {
+			Error("Failed to acquire state lock")
+			Info("Try increasing lock timeout with --lock-timeout=5m")
+			Info("Or check if another process is holding the lock")
+		} else {
+			Error("Initialization failed: %v", err)
+		}
+
+		ai.AIExplainError(opts.UseAI, err.Error())
 		return err
 	}
 
-	Success("Terraform backend and providers successfully initialized.")
+	// Display success message with backend info
+	displayBackendInfo(tf, opts)
+
 	return nil
+}
+
+// runInitWithRetry executes terraform init with retry logic for lock conflicts
+func runInitWithRetry(tf *tfexec.Terraform, initOptions []tfexec.InitOption, opts configs.InitOptions) error {
+	maxRetries := 3
+	retryDelay := 2 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		err := tf.Init(context.Background(), initOptions...)
+		if err == nil {
+			return nil
+		}
+
+		// Retry on lock conflicts
+		if strings.Contains(err.Error(), "state lock") && i < maxRetries-1 {
+			Warning("State lock detected, retrying in %v... (attempt %d/%d)", retryDelay, i+2, maxRetries)
+			time.Sleep(retryDelay)
+			retryDelay *= 2 // Exponential backoff
+			continue
+		}
+
+		return err
+	}
+
+	return fmt.Errorf("max retries exceeded")
+}
+
+// initFromModule handles initialization from a module source
+func initFromModule(opts configs.InitOptions) error {
+	Info("Initializing from module: %s", opts.FromModule)
+
+	tf, err := GetTerraform(opts.Dir)
+	if err != nil {
+		Error("Failed to initialize Terraform client: %v", err)
+		return err
+	}
+
+	// Use terraform init -from-module
+	err = tf.Init(context.Background(),
+		tfexec.FromModule(opts.FromModule),
+		tfexec.Upgrade(opts.Upgrade),
+		tfexec.Get(opts.Get),
+		tfexec.GetPlugins(opts.GetPlugins),
+	)
+
+	if err != nil {
+		Error("Failed to initialize from module: %v", err)
+		return err
+	}
+
+	Success("Successfully initialized from module: %s", opts.FromModule)
+	return nil
+}
+
+// displayBackendInfo shows information about the configured backend
+func displayBackendInfo(tf *tfexec.Terraform, opts configs.InitOptions) {
+	Success("Terraform backend and providers successfully initialized.")
+
+	// Show backend configuration info if available
+	if len(opts.BackendConfig) > 0 {
+		Info("Using backend configuration files:")
+		for _, config := range opts.BackendConfig {
+			Info("  • %s", config)
+		}
+	}
+
+	if opts.Reconfigure && opts.MigrateState {
+		Info("Backend reconfigured and state migration completed")
+	} else if opts.Reconfigure {
+		Info("Backend reconfigured (existing state preserved)")
+	} else if opts.MigrateState {
+		Info("State migrated to new backend")
+	}
+
+	// Provide next steps
+	Info("\nNext steps:")
+	Info("  1. Review infrastructure changes: smurf stf plan")
+	Info("  2. Apply infrastructure changes: smurf stf apply")
+	Info("  3. Check resource state: smurf stf state list")
+}
+
+// Init - Simplified version for backward compatibility
+func Init(dir string, upgrade, useAI bool) error {
+	return InitWithOptions(configs.InitOptions{
+		Dir:        dir,
+		Upgrade:    upgrade,
+		UseAI:      useAI,
+		Backend:    true,
+		Get:        true,
+		GetPlugins: true,
+		Lock:       true,
+	})
 }

--- a/internal/terraform/tfInit.go
+++ b/internal/terraform/tfInit.go
@@ -118,23 +118,6 @@ func InitWithOptions(opts configs.InitOptions) error {
 		initOptions = append(initOptions, tfexec.BackendConfig(config))
 	}
 
-	// Lock options
-	if !opts.Lock {
-		initOptions = append(initOptions, tfexec.Lock(false))
-	}
-
-	// Lock timeout - LockTimeout expects a string like "10s", not time.Duration
-	if opts.LockTimeout != "" && opts.LockTimeout != "0s" {
-		initOptions = append(initOptions, tfexec.LockTimeout(opts.LockTimeout))
-	}
-
-	// Plugin directory
-	if opts.PluginDir != "" {
-		os.Setenv("TF_PLUGIN_CACHE_DIR", opts.PluginDir)
-		Info("Using plugin directory: %s", opts.PluginDir)
-		defer os.Unsetenv("TF_PLUGIN_CACHE_DIR")
-	}
-
 	// Reconfigure (replaces existing backend config)
 	if opts.Reconfigure {
 		initOptions = append(initOptions, tfexec.Reconfigure(true))

--- a/internal/terraform/tfInit.go
+++ b/internal/terraform/tfInit.go
@@ -107,9 +107,16 @@ func InitWithOptions(opts configs.InitOptions) error {
 	// Basic options
 	initOptions = append(initOptions, tfexec.Upgrade(opts.Upgrade))
 	initOptions = append(initOptions, tfexec.Backend(opts.Backend))
-	initOptions = append(initOptions, tfexec.Get(opts.Get))
-	initOptions = append(initOptions, tfexec.GetPlugins(opts.GetPlugins))
-	initOptions = append(initOptions, tfexec.VerifyPlugins(opts.VerifyPlugins))
+
+	// Get modules - still supported
+	if !opts.Get {
+		initOptions = append(initOptions, tfexec.Get(false))
+	}
+
+	// Backend configuration
+	for _, config := range opts.BackendConfig {
+		initOptions = append(initOptions, tfexec.BackendConfig(config))
+	}
 
 	// Lock options
 	if !opts.Lock {
@@ -123,12 +130,9 @@ func InitWithOptions(opts configs.InitOptions) error {
 
 	// Plugin directory
 	if opts.PluginDir != "" {
-		initOptions = append(initOptions, tfexec.PluginDir(opts.PluginDir))
-	}
-
-	// Backend configuration
-	for _, config := range opts.BackendConfig {
-		initOptions = append(initOptions, tfexec.BackendConfig(config))
+		os.Setenv("TF_PLUGIN_CACHE_DIR", opts.PluginDir)
+		Info("Using plugin directory: %s", opts.PluginDir)
+		defer os.Unsetenv("TF_PLUGIN_CACHE_DIR")
 	}
 
 	// Reconfigure (replaces existing backend config)
@@ -138,24 +142,21 @@ func InitWithOptions(opts configs.InitOptions) error {
 
 	// Note: MigrateState and ForceCopy are not directly available in tfexec
 	// They need to be handled via environment variables or config options
-	// We'll handle them differently
-	if opts.MigrateState || opts.ForceCopy {
-		// Set environment variables for terraform to handle migration
-		if opts.MigrateState {
-			os.Setenv("TF_MIGRATE_STATE", "true")
-			defer os.Unsetenv("TF_MIGRATE_STATE")
-			Info("State migration enabled")
-		}
+	// Handle migrate-state and force-copy via environment variables
+	if opts.MigrateState {
+		os.Setenv("TF_MIGRATE_STATE", "true")
+		defer os.Unsetenv("TF_MIGRATE_STATE")
+		Info("State migration enabled")
+	}
 
-		if opts.ForceCopy {
-			os.Setenv("TF_FORCE_COPY", "true")
-			defer os.Unsetenv("TF_FORCE_COPY")
-			Info("Force copy mode enabled")
-		}
+	if opts.ForceCopy {
+		os.Setenv("TF_FORCE_COPY", "true")
+		defer os.Unsetenv("TF_FORCE_COPY")
+		Info("Force copy mode enabled")
 	}
 
 	// Execute init with retry logic for lock conflicts
-	err = runInitWithRetry(tf, initOptions, opts)
+	err = runInitWithRetry(tf, initOptions)
 	if err != nil {
 		// Check for specific error types and provide helpful messages
 		if strings.Contains(err.Error(), "backend configuration changed") {
@@ -176,13 +177,13 @@ func InitWithOptions(opts configs.InitOptions) error {
 	}
 
 	// Display success message with backend info
-	displayBackendInfo(tf, opts)
+	displayBackendInfo(opts)
 
 	return nil
 }
 
 // runInitWithRetry executes terraform init with retry logic for lock conflicts
-func runInitWithRetry(tf *tfexec.Terraform, initOptions []tfexec.InitOption, opts configs.InitOptions) error {
+func runInitWithRetry(tf *tfexec.Terraform, initOptions []tfexec.InitOption) error {
 	maxRetries := 3
 	retryDelay := 2 * time.Second
 
@@ -207,6 +208,7 @@ func runInitWithRetry(tf *tfexec.Terraform, initOptions []tfexec.InitOption, opt
 }
 
 // initFromModule handles initialization from a module source
+// initFromModule handles initialization from a module source
 func initFromModule(opts configs.InitOptions) error {
 	Info("Initializing from module: %s", opts.FromModule)
 
@@ -216,13 +218,18 @@ func initFromModule(opts configs.InitOptions) error {
 		return err
 	}
 
-	// Use terraform init -from-module
-	err = tf.Init(context.Background(),
-		tfexec.FromModule(opts.FromModule),
-		tfexec.Upgrade(opts.Upgrade),
-		tfexec.Get(opts.Get),
-		tfexec.GetPlugins(opts.GetPlugins),
-	)
+	// Build options for from-module
+	var options []tfexec.InitOption
+	options = append(options, tfexec.FromModule(opts.FromModule))
+	options = append(options, tfexec.Upgrade(opts.Upgrade))
+
+	// Get modules flag
+	if !opts.Get {
+		options = append(options, tfexec.Get(false))
+	}
+
+	// Execute init
+	err = tf.Init(context.Background(), options...)
 
 	if err != nil {
 		Error("Failed to initialize from module: %v", err)
@@ -234,7 +241,7 @@ func initFromModule(opts configs.InitOptions) error {
 }
 
 // displayBackendInfo shows information about the configured backend
-func displayBackendInfo(tf *tfexec.Terraform, opts configs.InitOptions) {
+func displayBackendInfo(opts configs.InitOptions) {
 	Success("Terraform backend and providers successfully initialized.")
 
 	// Show backend configuration info if available
@@ -263,12 +270,10 @@ func displayBackendInfo(tf *tfexec.Terraform, opts configs.InitOptions) {
 // Init - Simplified version for backward compatibility
 func Init(dir string, upgrade, useAI bool) error {
 	return InitWithOptions(configs.InitOptions{
-		Dir:        dir,
-		Upgrade:    upgrade,
-		UseAI:      useAI,
-		Backend:    true,
-		Get:        true,
-		GetPlugins: true,
-		Lock:       true,
+		Dir:     dir,
+		Upgrade: upgrade,
+		UseAI:   useAI,
+		Backend: true,
+		Get:     true,
 	})
 }


### PR DESCRIPTION
# Add Terraform init flags + GitHub workflows

### **New flags in `smurf stf init`:**
- --backend-config, --reconfigure, --migrate-state  
- --lock-timeout (with retry), --from-module, --plugin-dir

### **New workflows:**
- PR checks for concation commits and PR title validation
- Auto release tag based on label and update `CHANGELOG.md`

### **Benefits:**
- Backend migration support
- Clear error messages with fix suggestions
- Automated CI/CD


 ### **Example:**
```bash
smurf stf init --backend-config=prod.hcl