### PR TITLE
chore(deps): bump Go version from 1.25.5 to 1.25.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.8
   APP_PACKAGE: github.com/clouddrove/smurf/cmd 
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags: [ v* ]
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.8
   REPO: ${{ github.repository }}
   APP_PACKAGE: github.com/clouddrove/smurf/cmd
   BINARY_NAME: smurf

--- a/.github/workflows/test-multiplatform.yml
+++ b/.github/workflows/test-multiplatform.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: 1.25.5
+  GO_VERSION: 1.25.8
   TERRAFORM_VERSION: 1.1.7
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/clouddrove/smurf
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry v1.2.0
 	github.com/aws/aws-sdk-go v1.55.8
+	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/fatih/color v1.19.0
 	github.com/hashicorp/terraform-exec v0.25.0
@@ -56,7 +57,6 @@ require (
 	github.com/creack/pty v1.1.21 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect


### PR DESCRIPTION
### Updates the Go version to 1.25.8 as suggested by Dependabot.

---

- Verified that `go version` builds successfully
- Ran existing tests (`go test ./...`)
- Updated workflows 
