### PR TITLE
fix(provisionGHCR): add warning for get environment variable

### DIFF
--- a/cmd/sdkr/provisionGHCR.go
+++ b/cmd/sdkr/provisionGHCR.go
@@ -194,6 +194,7 @@ func ensureGHCRAuth(username, token string) error {
 func prepareBuildOptions() (docker.BuildOptions, error) {
 	if configs.ContextDir == "" {
 		wd, err := os.Getwd()
+		pterm.Error.Println("GitHub Container Registry credentials missing.")
 		if err != nil {
 			return docker.BuildOptions{}, fmt.Errorf("failed to get working directory: %v", err)
 		}

--- a/cmd/sdkr/provisionGHCR.go
+++ b/cmd/sdkr/provisionGHCR.go
@@ -194,7 +194,7 @@ func ensureGHCRAuth(username, token string) error {
 func prepareBuildOptions() (docker.BuildOptions, error) {
 	if configs.ContextDir == "" {
 		wd, err := os.Getwd()
-		pterm.Error.Println("GitHub Container Registry credentials missing.")
+pterm.Error.Println("Failed to determine working directory.")
 		if err != nil {
 			return docker.BuildOptions{}, fmt.Errorf("failed to get working directory: %v", err)
 		}


### PR DESCRIPTION
- Rename cmd/sdkr/providionGHCR.go → provisionGHCR.go **[#Issue 398](https://github.com/clouddrove/smurf/issues/398)**

- provisionGcp: os.Getwd() failure warns and continues with wrong cwd **[#issue 399](https://github.com/clouddrove/smurf/issues/399)**