### PR TITLE
feat: enhance smurf selm logs to capture terminated pod details during failed deployments

### DIFF
--- a/internal/helm/common.go
+++ b/internal/helm/common.go
@@ -297,30 +297,43 @@ func describeFailedResources(namespace, releaseName string) {
 	}
 
 	for _, pod := range podList.Items {
-		pterm.FgGreen.Printfln("Pod: %s \n", pod.Name)
-		pterm.FgGreen.Printfln("Phase: %s \n", pod.Status.Phase)
+		status := getKubectlLikeStatus(pod)
+		unhealthy := isPodUnhealthyForUpgrade(&pod) ||
+			pod.Status.Phase == corev1.PodFailed ||
+			strings.Contains(status, "CrashLoopBackOff") ||
+			strings.Contains(status, "ImagePullBackOff") ||
+			strings.Contains(status, "Failed")
+
+		if !unhealthy {
+			continue
+		}
+
+		pterm.Error.Printfln("Pod: %s — %s", pod.Name, status)
+		pterm.Error.Printfln("Phase: %s", pod.Status.Phase)
 		for _, cs := range pod.Status.ContainerStatuses {
 			if cs.State.Waiting != nil {
-				pterm.FgRed.Printfln("Container: %s is waiting with reason: %s, message: %s \n", cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+				pterm.FgRed.Printfln("Container: %s is waiting with reason: %s, message: %s", cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
 			} else if cs.State.Terminated != nil {
-				pterm.FgRed.Printfln("Container: %s is terminated with reason: %s, message: %s \n", cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.Message)
+				pterm.FgRed.Printfln("Container: %s is terminated with reason: %s, message: %s", cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.Message)
 			}
 		}
+
+		printFailedPodLogs(clientset, namespace, pod)
 
 		evts, err := clientset.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{
 			FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name),
 		})
 		if err != nil {
-			pterm.Warning.Printfln("Error fetching events for pod %s: %v \n", pod.Name, err)
+			pterm.Warning.Printfln("Error fetching events for pod %s: %v", pod.Name, err)
 			continue
 		}
 
 		if len(evts.Items) == 0 {
-			pterm.Warning.Printfln("No events found for pod %s \n", pod.Name)
+			pterm.Warning.Printfln("No events found for pod %s", pod.Name)
 		} else {
-			pterm.FgGreen.Printfln("Events for pod %s: \n", pod.Name)
+			pterm.FgGreen.Printfln("Events for pod %s:", pod.Name)
 			for _, evt := range evts.Items {
-				pterm.FgGreen.Printfln("  %s: %s \n", evt.Reason, evt.Message)
+				pterm.FgGreen.Printfln("  %s: %s", evt.Reason, evt.Message)
 			}
 		}
 		pterm.FgCyan.Println("-------------------------------------------------------")

--- a/internal/helm/pod_logs.go
+++ b/internal/helm/pod_logs.go
@@ -1,0 +1,238 @@
+package helm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const defaultPodLogTailLines int64 = 100
+
+type podLogFetchOpts struct {
+	container string
+	previous  bool
+	tailLines int64
+}
+
+// fetchPodContainerLogs retrieves logs for a pod container (kubectl logs equivalent).
+func fetchPodContainerLogs(
+	clientset *kubernetes.Clientset,
+	namespace, podName string,
+	opts podLogFetchOpts,
+) (string, error) {
+	tail := opts.tailLines
+	if tail <= 0 {
+		tail = defaultPodLogTailLines
+	}
+
+	podLogOpts := corev1.PodLogOptions{
+		Container: opts.container,
+		TailLines: &tail,
+		Previous:  opts.previous,
+	}
+
+	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
+	stream, err := req.Stream(context.Background())
+	if err != nil {
+		return "", err
+	}
+	defer stream.Close()
+
+	buf := new(strings.Builder)
+	if _, err := io.Copy(buf, stream); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func kubectlLogsCommand(namespace, podName, container string, previous bool, tail int64) string {
+	parts := []string{"kubectl", "logs", podName, "-n", namespace}
+	if container != "" {
+		parts = append(parts, "-c", container)
+	}
+	if previous {
+		parts = append(parts, "--previous")
+	}
+	if tail > 0 {
+		parts = append(parts, fmt.Sprintf("--tail=%d", tail))
+	}
+	return strings.Join(parts, " ")
+}
+
+func isContainerStatusUnhealthy(cs corev1.ContainerStatus) bool {
+	if cs.State.Waiting != nil {
+		switch cs.State.Waiting.Reason {
+		case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
+			"CreateContainerConfigError", "InvalidImageName", "CreateContainerError",
+			"RunContainerError", "StartError":
+			return true
+		}
+	}
+	if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+		return true
+	}
+	if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.ExitCode != 0 {
+		return true
+	}
+	return false
+}
+
+func containerNeedsPreviousLogs(cs corev1.ContainerStatus) bool {
+	if cs.LastTerminationState.Terminated != nil {
+		return true
+	}
+	if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
+		return true
+	}
+	if cs.RestartCount > 0 {
+		return true
+	}
+	return false
+}
+
+type containerLogTarget struct {
+	name     string
+	init     bool
+	previous bool
+}
+
+func containersForLogFetch(pod *corev1.Pod) []containerLogTarget {
+	seen := make(map[string]bool)
+	var targets []containerLogTarget
+
+	add := func(name string, init bool, cs corev1.ContainerStatus) {
+		key := name
+		if init {
+			key = "init:" + name
+		}
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		targets = append(targets, containerLogTarget{
+			name:     name,
+			init:     init,
+			previous: containerNeedsPreviousLogs(cs),
+		})
+	}
+
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if isContainerStatusUnhealthy(cs) || pod.Status.Phase == corev1.PodFailed {
+			add(cs.Name, true, cs)
+		}
+	}
+
+	unhealthyFound := false
+	for _, cs := range pod.Status.ContainerStatuses {
+		if isContainerStatusUnhealthy(cs) {
+			unhealthyFound = true
+			add(cs.Name, false, cs)
+		}
+	}
+
+	if !unhealthyFound {
+		if len(pod.Spec.Containers) == 1 {
+			name := pod.Spec.Containers[0].Name
+			var cs corev1.ContainerStatus
+			if len(pod.Status.ContainerStatuses) > 0 {
+				cs = pod.Status.ContainerStatuses[0]
+			}
+			add(name, false, cs)
+		} else {
+			for i, c := range pod.Spec.Containers {
+				var cs corev1.ContainerStatus
+				if i < len(pod.Status.ContainerStatuses) {
+					cs = pod.Status.ContainerStatuses[i]
+				}
+				add(c.Name, false, cs)
+			}
+		}
+	}
+
+	return targets
+}
+
+func printLogSectionHeader(title, kubectlCmd string) {
+	fmt.Println()
+	pterm.DefaultSection.WithLevel(2).Println(title)
+	fmt.Printf("  %s%s%s\n", pterm.Gray("$ "), pterm.Cyan(kubectlCmd), pterm.Gray(""))
+	fmt.Println(strings.Repeat("-", 80))
+}
+
+func printLogSectionBody(logs string, fetchErr error) {
+	if fetchErr != nil {
+		pterm.Warning.Printf("  (logs unavailable: %v)\n", fetchErr)
+		fmt.Println(strings.Repeat("-", 80))
+		return
+	}
+
+	trimmed := strings.TrimRight(logs, "\n")
+	if trimmed == "" {
+		pterm.Warning.Println("  (no log output)")
+	} else {
+		fmt.Println(trimmed)
+	}
+	fmt.Println(strings.Repeat("-", 80))
+}
+
+// printFailedPodLogs prints pod logs in kubectl-style sections (current + --previous when needed).
+func printFailedPodLogs(clientset *kubernetes.Clientset, namespace string, pod corev1.Pod) {
+	targets := containersForLogFetch(&pod)
+	if len(targets) == 0 {
+		pterm.Warning.Printf("No containers to fetch logs for pod %s\n", pod.Name)
+		return
+	}
+
+	multiContainer := len(pod.Spec.Containers) > 1
+
+	for _, target := range targets {
+		containerLabel := target.name
+		if target.init {
+			containerLabel = target.name + " (init)"
+		}
+
+		// Current instance logs (kubectl logs podname)
+		containerArg := ""
+		if multiContainer || target.init {
+			containerArg = target.name
+		}
+		currentCmd := kubectlLogsCommand(namespace, pod.Name, containerArg, false, defaultPodLogTailLines)
+
+		title := fmt.Sprintf("Logs — %s", containerLabel)
+		printLogSectionHeader(title, currentCmd)
+
+		logs, err := fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
+			container: target.name,
+			previous:  false,
+			tailLines: defaultPodLogTailLines,
+		})
+		printLogSectionBody(logs, err)
+
+		// Previous instance logs (kubectl logs podname --previous) for crash loops
+		if target.previous {
+			prevCmd := kubectlLogsCommand(namespace, pod.Name, target.name, true, defaultPodLogTailLines)
+			printLogSectionHeader(fmt.Sprintf("Previous logs — %s", containerLabel), prevCmd)
+
+			prevLogs, prevErr := fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
+				container: target.name,
+				previous:  true,
+				tailLines: defaultPodLogTailLines,
+			})
+			printLogSectionBody(prevLogs, prevErr)
+		}
+	}
+}
+
+// getPodLogs kept for callers that only need raw log text.
+func getPodLogs(clientset *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64) (string, error) {
+	return fetchPodContainerLogs(clientset, namespace, podName, podLogFetchOpts{
+		container: containerName,
+		tailLines: tailLines,
+	})
+}

--- a/internal/helm/pod_logs.go
+++ b/internal/helm/pod_logs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/pterm/pterm"
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +13,21 @@ import (
 )
 
 const defaultPodLogTailLines int64 = 100
+
+type cachedPodDiagnostics struct {
+	current    map[string]string // container -> current logs
+	previous   map[string]string // container -> previous logs
+	events     []corev1.Event
+	capturedAt time.Time
+	podExists  bool
+}
+
+func newCachedPodDiagnostics() *cachedPodDiagnostics {
+	return &cachedPodDiagnostics{
+		current:  make(map[string]string),
+		previous: make(map[string]string),
+	}
+}
 
 type podLogFetchOpts struct {
 	container string
@@ -181,8 +197,119 @@ func printLogSectionBody(logs string, fetchErr error) {
 	fmt.Println(strings.Repeat("-", 80))
 }
 
-// printFailedPodLogs prints pod logs in kubectl-style sections (current + --previous when needed).
+func containerNeverStarted(cs corev1.ContainerStatus) bool {
+	if cs.State.Waiting == nil {
+		return false
+	}
+	switch cs.State.Waiting.Reason {
+	case "ImagePullBackOff", "ErrImagePull", "InvalidImageName",
+		"CreateContainerConfigError", "CreateContainerError", "PodInitializing":
+		return true
+	}
+	return false
+}
+
+func capturePodDiagnostics(clientset *kubernetes.Clientset, namespace string, pod *corev1.Pod) *cachedPodDiagnostics {
+	cache := newCachedPodDiagnostics()
+	cache.capturedAt = time.Now()
+	cache.podExists = true
+
+	for _, target := range containersForLogFetch(pod) {
+		if logs, err := fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
+			container: target.name,
+			previous:  false,
+			tailLines: defaultPodLogTailLines,
+		}); err == nil && strings.TrimSpace(logs) != "" {
+			cache.current[target.name] = logs
+		}
+
+		if target.previous {
+			if logs, err := fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
+				container: target.name,
+				previous:  true,
+				tailLines: defaultPodLogTailLines,
+			}); err == nil && strings.TrimSpace(logs) != "" {
+				cache.previous[target.name] = logs
+			}
+		}
+	}
+
+	if events, err := getPodEvents(clientset, namespace, pod.Name); err == nil {
+		cache.events = events
+	}
+
+	return cache
+}
+
+func mergePodDiagnostics(existing, fresh *cachedPodDiagnostics) *cachedPodDiagnostics {
+	if existing == nil {
+		return fresh
+	}
+	if fresh == nil {
+		return existing
+	}
+
+	for k, v := range fresh.current {
+		if v != "" {
+			existing.current[k] = v
+		}
+	}
+	for k, v := range fresh.previous {
+		if v != "" {
+			existing.previous[k] = v
+		}
+	}
+	if len(fresh.events) > 0 {
+		existing.events = fresh.events
+	}
+	if !fresh.capturedAt.IsZero() {
+		existing.capturedAt = fresh.capturedAt
+	}
+	existing.podExists = fresh.podExists
+	return existing
+}
+
+func printPodEventsSection(events []corev1.Event, title string) {
+	if len(events) == 0 {
+		return
+	}
+	fmt.Println()
+	pterm.DefaultSection.WithLevel(2).Println(title)
+	fmt.Println("  Type    Reason              Message")
+	fmt.Println("  ----    ------              -------")
+	for _, evt := range events {
+		icon := "ℹ"
+		if evt.Type == "Warning" {
+			icon = "⚠"
+		}
+		fmt.Printf("  %s %-7s %-19s %s\n", icon, evt.Type, evt.Reason, evt.Message)
+	}
+	fmt.Println(strings.Repeat("-", 80))
+}
+
+func printContainerNeverStartedReason(pod corev1.Pod, containerName string) {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name != containerName {
+			continue
+		}
+		if cs.State.Waiting != nil {
+			pterm.Warning.Printf("  Container never started — no runtime logs available.\n")
+			pterm.Error.Printf("  Reason  : %s\n", cs.State.Waiting.Reason)
+			if cs.State.Waiting.Message != "" {
+				pterm.Error.Printf("  Message : %s\n", cs.State.Waiting.Message)
+			}
+			return
+		}
+	}
+}
+
+// printFailedPodLogs prints pod logs fetched live from the cluster.
 func printFailedPodLogs(clientset *kubernetes.Clientset, namespace string, pod corev1.Pod) {
+	printFailedPodLogsWithCache(clientset, namespace, pod, nil)
+}
+
+// printFailedPodLogsWithCache prints logs from cache (captured during upgrade) with live fallback.
+func printFailedPodLogsWithCache(clientset *kubernetes.Clientset, namespace string, pod corev1.Pod, cache *cachedPodDiagnostics) {
 	targets := containersForLogFetch(&pod)
 	if len(targets) == 0 {
 		pterm.Warning.Printf("No containers to fetch logs for pod %s\n", pod.Name)
@@ -190,6 +317,7 @@ func printFailedPodLogs(clientset *kubernetes.Clientset, namespace string, pod c
 	}
 
 	multiContainer := len(pod.Spec.Containers) > 1
+	podRemoved := cache != nil && !cache.podExists
 
 	for _, target := range targets {
 		containerLabel := target.name
@@ -197,7 +325,6 @@ func printFailedPodLogs(clientset *kubernetes.Clientset, namespace string, pod c
 			containerLabel = target.name + " (init)"
 		}
 
-		// Current instance logs (kubectl logs podname)
 		containerArg := ""
 		if multiContainer || target.init {
 			containerArg = target.name
@@ -205,28 +332,80 @@ func printFailedPodLogs(clientset *kubernetes.Clientset, namespace string, pod c
 		currentCmd := kubectlLogsCommand(namespace, pod.Name, containerArg, false, defaultPodLogTailLines)
 
 		title := fmt.Sprintf("Logs — %s", containerLabel)
+		if podRemoved {
+			title += " (captured before pod removal)"
+		}
 		printLogSectionHeader(title, currentCmd)
 
-		logs, err := fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
-			container: target.name,
-			previous:  false,
-			tailLines: defaultPodLogTailLines,
-		})
-		printLogSectionBody(logs, err)
+		var logs string
+		var fetchErr error
 
-		// Previous instance logs (kubectl logs podname --previous) for crash loops
-		if target.previous {
-			prevCmd := kubectlLogsCommand(namespace, pod.Name, target.name, true, defaultPodLogTailLines)
-			printLogSectionHeader(fmt.Sprintf("Previous logs — %s", containerLabel), prevCmd)
-
-			prevLogs, prevErr := fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
+		if cache != nil {
+			if cached, ok := cache.current[target.name]; ok && strings.TrimSpace(cached) != "" {
+				logs = cached
+			}
+		}
+		if logs == "" && !podRemoved {
+			logs, fetchErr = fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
 				container: target.name,
-				previous:  true,
+				previous:  false,
 				tailLines: defaultPodLogTailLines,
 			})
+		} else if logs == "" && podRemoved {
+			fetchErr = fmt.Errorf("pod %q was removed during rollback (no cached logs)", pod.Name)
+		}
+
+		if logs != "" {
+			printLogSectionBody(logs, nil)
+		} else if containerNeverStarted(findContainerStatus(pod, target.name)) {
+			printContainerNeverStartedReason(pod, target.name)
+			if cache != nil && len(cache.events) > 0 {
+				printPodEventsSection(cache.events, "Pod Events (captured during failure)")
+			} else if events, err := getPodEvents(clientset, namespace, pod.Name); err == nil {
+				printPodEventsSection(events, "Pod Events")
+			}
+			fmt.Println(strings.Repeat("-", 80))
+		} else {
+			printLogSectionBody("", fetchErr)
+			if cache != nil && len(cache.events) > 0 {
+				printPodEventsSection(cache.events, "Pod Events (captured during failure)")
+			}
+		}
+
+		if target.previous {
+			prevCmd := kubectlLogsCommand(namespace, pod.Name, target.name, true, defaultPodLogTailLines)
+			prevTitle := fmt.Sprintf("Previous logs — %s", containerLabel)
+			if podRemoved {
+				prevTitle += " (captured before pod removal)"
+			}
+			printLogSectionHeader(prevTitle, prevCmd)
+
+			var prevLogs string
+			var prevErr error
+			if cache != nil {
+				if cached, ok := cache.previous[target.name]; ok && strings.TrimSpace(cached) != "" {
+					prevLogs = cached
+				}
+			}
+			if prevLogs == "" && !podRemoved {
+				prevLogs, prevErr = fetchPodContainerLogs(clientset, namespace, pod.Name, podLogFetchOpts{
+					container: target.name,
+					previous:  true,
+					tailLines: defaultPodLogTailLines,
+				})
+			}
 			printLogSectionBody(prevLogs, prevErr)
 		}
 	}
+}
+
+func findContainerStatus(pod corev1.Pod, name string) corev1.ContainerStatus {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == name {
+			return cs
+		}
+	}
+	return corev1.ContainerStatus{Name: name}
 }
 
 // getPodLogs kept for callers that only need raw log text.

--- a/internal/helm/upgrade.go
+++ b/internal/helm/upgrade.go
@@ -3,7 +3,6 @@ package helm
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -144,18 +143,25 @@ func HelmUpgrade(
 	fmt.Printf("🚀 Starting upgrade for release '%s'...\n", releaseName)
 	upgradeStartTime := time.Now()
 
+	podMonitor, monitorErr := newUpgradePodMonitor(namespace, releaseName, debug)
+	if monitorErr != nil {
+		if debug {
+			pterm.Warning.Printf("Could not start upgrade pod monitor: %v\n", monitorErr)
+		}
+	} else {
+		podMonitor.start()
+		defer podMonitor.stop()
+	}
+
 	// Run the upgrade
 	rel, err := client.Run(releaseName, chart, vals)
 	if err != nil {
-		errorMsg := err.Error()
-		if atomic && strings.Contains(errorMsg, "rolled back") {
-			fmt.Printf("\n⚠️  Upgrade failed and rollback may have issues\n")
-
-			// Check if rollback actually happened
-			handleInstallationSuccess(rel, namespace)
-			printFinalPodStatus(namespace, releaseName, debug)
+		if podMonitor != nil {
+			printUpgradeFailureDiagnostics(namespace, releaseName, podMonitor, atomic, err, debug)
+		} else {
+			describeFailedResources(namespace, releaseName)
+			printReleaseResources(namespace, releaseName)
 		}
-		//printReleaseResources(namespace, releaseName)
 		printErrorSummary("Helm upgradation", releaseName, namespace, chartRef, err)
 		ai.AIExplainError(useAI, err.Error())
 		return fmt.Errorf("upgrade failed: %w", err)
@@ -176,6 +182,12 @@ func HelmUpgrade(
 	handleInstallationSuccess(rel, namespace)
 
 	if err := printFinalPodStatus(namespace, releaseName, debug); err != nil {
+		if podMonitor != nil {
+			printUpgradeFailureDiagnostics(namespace, releaseName, podMonitor, atomic, err, debug)
+		} else {
+			describeFailedResources(namespace, releaseName)
+			printReleaseResources(namespace, releaseName)
+		}
 		printErrorSummary("Pod not healthy", releaseName, namespace, chartRef, err)
 		ai.AIExplainError(useAI, err.Error())
 		return fmt.Errorf("upgrade failed: %w", err)
@@ -951,29 +963,6 @@ func isPodFromRelease(pod corev1.Pod, releaseName string) bool {
 	return false
 }
 
-// Helper function to get pod logs
-func getPodLogs(clientset *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64) (string, error) {
-	podLogOpts := corev1.PodLogOptions{
-		Container: containerName,
-		TailLines: &tailLines,
-	}
-
-	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
-	podLogs, err := req.Stream(context.Background())
-	if err != nil {
-		return "", err
-	}
-	defer podLogs.Close()
-
-	buf := new(strings.Builder)
-	_, err = io.Copy(buf, podLogs)
-	if err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
-}
-
 // Print status summary
 func printStatusSummary(statusCount map[string]int, total int) {
 	fmt.Printf("📈 Status: ")
@@ -1196,24 +1185,6 @@ func describePod(clientset *kubernetes.Clientset, pod corev1.Pod, namespace stri
 				age.String(),
 				event.Source.Component,
 				event.Message)
-		}
-	}
-
-	// Show logs for failed/error containers
-	if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodPending {
-		for _, cs := range pod.Status.ContainerStatuses {
-			if cs.State.Waiting != nil || (cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0) {
-				fmt.Printf("\n📝 Attempting to get logs for container '%s':\n", cs.Name)
-				logs, err := getPodLogs(clientset, namespace, pod.Name, cs.Name, 20) // last 20 lines
-				if err != nil {
-					fmt.Printf("  ❌ Failed : %v\n", err)
-				} else if logs != "" {
-					fmt.Println("  Last 20 lines of logs:")
-					fmt.Println(strings.Repeat("-", 40))
-					fmt.Println(logs)
-					fmt.Println(strings.Repeat("-", 40))
-				}
-			}
 		}
 	}
 

--- a/internal/helm/upgrade_monitor.go
+++ b/internal/helm/upgrade_monitor.go
@@ -15,18 +15,25 @@ import (
 
 const upgradePodPollInterval = 2 * time.Second
 
+type failedPodSnapshot struct {
+	pod   *corev1.Pod
+	cache *cachedPodDiagnostics
+}
+
 // upgradePodMonitor watches pods during a Helm upgrade and snapshots unhealthy states
-// before atomic rollback or cleanup removes them from the cluster.
+// plus logs/events before atomic rollback removes pods from the cluster.
 type upgradePodMonitor struct {
 	clientset   *kubernetes.Clientset
 	namespace   string
 	releaseName string
 	debug       bool
 
-	mu        sync.Mutex
-	snapshots map[string]*corev1.Pod
-	stopCh    chan struct{}
-	doneCh    chan struct{}
+	mu          sync.Mutex
+	snapshots   map[string]*corev1.Pod
+	diagnostics map[string]*cachedPodDiagnostics
+	seenPods    map[string]bool
+	stopCh      chan struct{}
+	doneCh      chan struct{}
 }
 
 func newUpgradePodMonitor(namespace, releaseName string, debug bool) (*upgradePodMonitor, error) {
@@ -41,6 +48,8 @@ func newUpgradePodMonitor(namespace, releaseName string, debug bool) (*upgradePo
 		releaseName: releaseName,
 		debug:       debug,
 		snapshots:   make(map[string]*corev1.Pod),
+		diagnostics: make(map[string]*cachedPodDiagnostics),
+		seenPods:    make(map[string]bool),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}, nil
@@ -87,22 +96,52 @@ func (m *upgradePodMonitor) poll() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	currentPods := make(map[string]bool, len(pods))
 	for i := range pods {
 		pod := pods[i]
+		currentPods[pod.Name] = true
+		m.seenPods[pod.Name] = true
+
 		if isPodUnhealthyForUpgrade(&pod) {
-			copy := pod.DeepCopy()
-			m.snapshots[pod.Name] = copy
+			m.snapshots[pod.Name] = pod.DeepCopy()
+			fresh := capturePodDiagnostics(m.clientset, m.namespace, &pod)
+			m.diagnostics[pod.Name] = mergePodDiagnostics(m.diagnostics[pod.Name], fresh)
+
+			if m.debug {
+				pterm.Debug.Printf("upgrade monitor: captured diagnostics for unhealthy pod %s\n", pod.Name)
+			}
+		}
+	}
+
+	// Pods that disappeared (scaled down / rollback) — mark cache as pod removed
+	for name := range m.seenPods {
+		if currentPods[name] {
+			continue
+		}
+		if cache, ok := m.diagnostics[name]; ok {
+			cache.podExists = false
+		}
+		if m.debug {
+			pterm.Debug.Printf("upgrade monitor: pod %s removed from cluster\n", name)
 		}
 	}
 }
 
-func (m *upgradePodMonitor) failedSnapshots() []*corev1.Pod {
+func (m *upgradePodMonitor) failedSnapshots() []failedPodSnapshot {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	result := make([]*corev1.Pod, 0, len(m.snapshots))
-	for _, pod := range m.snapshots {
-		result = append(result, pod.DeepCopy())
+	result := make([]failedPodSnapshot, 0, len(m.snapshots))
+	for name, pod := range m.snapshots {
+		cache := m.diagnostics[name]
+		if cache == nil {
+			cache = newCachedPodDiagnostics()
+			cache.podExists = false
+		}
+		result = append(result, failedPodSnapshot{
+			pod:   pod.DeepCopy(),
+			cache: cache,
+		})
 	}
 	return result
 }
@@ -153,7 +192,8 @@ func printDiagnosticsSubSection(title string) {
 	fmt.Println(strings.Repeat("─", 80))
 }
 
-func printFailedPodReport(clientset *kubernetes.Clientset, namespace string, pod corev1.Pod, index, total int) {
+func printFailedPodReport(clientset *kubernetes.Clientset, namespace string, snapshot failedPodSnapshot, index, total int) {
+	pod := *snapshot.pod
 	status := getKubectlLikeStatus(pod)
 
 	printDiagnosticsSubSection(fmt.Sprintf("Failed Pod [%d/%d]: %s", index, total, pod.Name))
@@ -162,6 +202,13 @@ func printFailedPodReport(clientset *kubernetes.Clientset, namespace string, pod
 	fmt.Printf("  Phase     : %s\n", pod.Status.Phase)
 	fmt.Printf("  Node      : %s\n", podOrNone(pod.Spec.NodeName))
 
+	if snapshot.cache != nil && !snapshot.cache.capturedAt.IsZero() {
+		fmt.Printf("  Captured  : %s\n", snapshot.cache.capturedAt.Format(dateTimeFormat))
+	}
+	if snapshot.cache != nil && !snapshot.cache.podExists {
+		pterm.Warning.Println("  Note      : Pod was removed during rollback — showing captured state")
+	}
+
 	for _, cs := range pod.Status.ContainerStatuses {
 		state := containerStateSummary(cs)
 		if state != "" {
@@ -169,8 +216,43 @@ func printFailedPodReport(clientset *kubernetes.Clientset, namespace string, pod
 		}
 	}
 
-	describePod(clientset, pod, namespace, false)
-	printFailedPodLogs(clientset, namespace, pod)
+	describePodFromSnapshot(clientset, pod, namespace, snapshot.cache)
+	printFailedPodLogsWithCache(clientset, namespace, pod, snapshot.cache)
+}
+
+func describePodFromSnapshot(clientset *kubernetes.Clientset, pod corev1.Pod, namespace string, cache *cachedPodDiagnostics) {
+	fmt.Printf("\n📋 Pod Details: %s\n", pod.Name)
+	fmt.Println(strings.Repeat("=", 50))
+
+	fmt.Println("\nStatus:")
+	fmt.Printf("  Phase:   %s\n", pod.Status.Phase)
+	fmt.Printf("  Reason:  %s\n", pod.Status.Reason)
+	fmt.Printf("  Message: %s\n", pod.Status.Message)
+
+	if len(pod.Status.ContainerStatuses) > 0 {
+		fmt.Println("\nContainers:")
+		for i, cs := range pod.Status.ContainerStatuses {
+			fmt.Printf("  Container %d: %s\n", i+1, cs.Name)
+			fmt.Printf("    Image:         %s\n", cs.Image)
+			fmt.Printf("    Ready:         %v\n", cs.Ready)
+			if cs.State.Waiting != nil {
+				fmt.Printf("    State:         Waiting (%s)\n", cs.State.Waiting.Reason)
+				fmt.Printf("    Message:       %s\n", cs.State.Waiting.Message)
+			}
+		}
+	}
+
+	if cache != nil && len(cache.events) > 0 {
+		printPodEventsSection(cache.events, "Events (captured during failure)")
+		return
+	}
+
+	events, err := getPodEvents(clientset, namespace, pod.Name)
+	if err == nil && len(events) > 0 {
+		printPodEventsSection(events, "Events")
+	}
+
+	fmt.Println(strings.Repeat("=", 50))
 }
 
 func podOrNone(value string) string {
@@ -207,8 +289,8 @@ func printUpgradeFailureDiagnostics(namespace, releaseName string, monitor *upgr
 
 	if atomic {
 		printDiagnosticsSubSection("Rollback Notice")
-		pterm.Warning.Println("Atomic rollback may have removed failed pods from the cluster.")
-		pterm.Warning.Println("Showing captured pod state and logs collected during the upgrade.")
+		pterm.Warning.Println("Atomic rollback removed failed pods from the cluster.")
+		pterm.Warning.Println("Logs and events below were captured while the pod was still running.")
 	}
 
 	clientset, err := getKubeClient()
@@ -220,8 +302,8 @@ func printUpgradeFailureDiagnostics(namespace, releaseName string, monitor *upgr
 	snapshots := monitor.failedSnapshots()
 	if len(snapshots) > 0 {
 		printDiagnosticsSubSection(fmt.Sprintf("Failed Pods During Rollout (%d)", len(snapshots)))
-		for i, pod := range snapshots {
-			printFailedPodReport(clientset, namespace, *pod, i+1, len(snapshots))
+		for i, snapshot := range snapshots {
+			printFailedPodReport(clientset, namespace, snapshot, i+1, len(snapshots))
 		}
 	}
 
@@ -242,12 +324,14 @@ func printUpgradeFailureDiagnostics(namespace, releaseName string, monitor *upgr
 			pterm.Warning.Printf("Current pod status: %v\n", err)
 		}
 
-		// Try live failed pods and fetch kubectl-style logs
 		livePods, listErr := getPods(namespace, releaseName)
 		if listErr == nil {
 			for _, pod := range livePods {
 				if isPodUnhealthyForUpgrade(&pod) {
-					printFailedPodReport(clientset, namespace, pod, 1, 1)
+					printFailedPodReport(clientset, namespace, failedPodSnapshot{
+						pod:   pod.DeepCopy(),
+						cache: capturePodDiagnostics(clientset, namespace, &pod),
+					}, 1, 1)
 				}
 			}
 		}

--- a/internal/helm/upgrade_monitor.go
+++ b/internal/helm/upgrade_monitor.go
@@ -1,0 +1,304 @@
+package helm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const upgradePodPollInterval = 2 * time.Second
+
+// upgradePodMonitor watches pods during a Helm upgrade and snapshots unhealthy states
+// before atomic rollback or cleanup removes them from the cluster.
+type upgradePodMonitor struct {
+	clientset   *kubernetes.Clientset
+	namespace   string
+	releaseName string
+	debug       bool
+
+	mu        sync.Mutex
+	snapshots map[string]*corev1.Pod
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+func newUpgradePodMonitor(namespace, releaseName string, debug bool) (*upgradePodMonitor, error) {
+	clientset, err := getKubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &upgradePodMonitor{
+		clientset:   clientset,
+		namespace:   namespace,
+		releaseName: releaseName,
+		debug:       debug,
+		snapshots:   make(map[string]*corev1.Pod),
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
+	}, nil
+}
+
+func (m *upgradePodMonitor) start() {
+	go func() {
+		defer close(m.doneCh)
+
+		ticker := time.NewTicker(upgradePodPollInterval)
+		defer ticker.Stop()
+
+		m.poll()
+		for {
+			select {
+			case <-m.stopCh:
+				m.poll()
+				return
+			case <-ticker.C:
+				m.poll()
+			}
+		}
+	}()
+}
+
+func (m *upgradePodMonitor) stop() {
+	select {
+	case <-m.stopCh:
+	default:
+		close(m.stopCh)
+	}
+	<-m.doneCh
+}
+
+func (m *upgradePodMonitor) poll() {
+	pods, err := getPods(m.namespace, m.releaseName)
+	if err != nil {
+		if m.debug {
+			pterm.Debug.Printf("upgrade monitor: failed to list pods: %v\n", err)
+		}
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i := range pods {
+		pod := pods[i]
+		if isPodUnhealthyForUpgrade(&pod) {
+			copy := pod.DeepCopy()
+			m.snapshots[pod.Name] = copy
+		}
+	}
+}
+
+func (m *upgradePodMonitor) failedSnapshots() []*corev1.Pod {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]*corev1.Pod, 0, len(m.snapshots))
+	for _, pod := range m.snapshots {
+		result = append(result, pod.DeepCopy())
+	}
+	return result
+}
+
+func isPodUnhealthyForUpgrade(pod *corev1.Pod) bool {
+	if isPodInFailureState(pod) {
+		return true
+	}
+
+	if pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
+			return true
+		}
+		if cs.State.Waiting != nil {
+			switch cs.State.Waiting.Reason {
+			case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
+				"CreateContainerConfigError", "InvalidImageName", "CreateContainerError":
+				return true
+			}
+		}
+	}
+
+	if pod.Status.Phase == corev1.PodRunning && !isPodReady(*pod) {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if !cs.Ready && cs.State.Waiting != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func printDiagnosticsBanner(title string) {
+	fmt.Println()
+	fmt.Println(strings.Repeat("═", 80))
+	pterm.Error.Println(title)
+	fmt.Println(strings.Repeat("═", 80))
+}
+
+func printDiagnosticsSubSection(title string) {
+	fmt.Println()
+	pterm.DefaultSection.WithLevel(2).Println(title)
+	fmt.Println(strings.Repeat("─", 80))
+}
+
+func printFailedPodReport(clientset *kubernetes.Clientset, namespace string, pod corev1.Pod, index, total int) {
+	status := getKubectlLikeStatus(pod)
+
+	printDiagnosticsSubSection(fmt.Sprintf("Failed Pod [%d/%d]: %s", index, total, pod.Name))
+	fmt.Printf("  Namespace : %s\n", namespace)
+	fmt.Printf("  Status    : %s\n", status)
+	fmt.Printf("  Phase     : %s\n", pod.Status.Phase)
+	fmt.Printf("  Node      : %s\n", podOrNone(pod.Spec.NodeName))
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		state := containerStateSummary(cs)
+		if state != "" {
+			fmt.Printf("  Container : %s — %s\n", cs.Name, state)
+		}
+	}
+
+	describePod(clientset, pod, namespace, false)
+	printFailedPodLogs(clientset, namespace, pod)
+}
+
+func podOrNone(value string) string {
+	if value == "" {
+		return none
+	}
+	return value
+}
+
+func containerStateSummary(cs corev1.ContainerStatus) string {
+	switch {
+	case cs.State.Waiting != nil:
+		return fmt.Sprintf("Waiting (%s): %s", cs.State.Waiting.Reason, cs.State.Waiting.Message)
+	case cs.State.Terminated != nil:
+		return fmt.Sprintf("Terminated (%s, exit %d): %s",
+			cs.State.Terminated.Reason, cs.State.Terminated.ExitCode, cs.State.Terminated.Message)
+	case cs.State.Running != nil:
+		if !cs.Ready {
+			return "Running (not ready)"
+		}
+		return "Running (ready)"
+	default:
+		return ""
+	}
+}
+
+func printUpgradeFailureDiagnostics(namespace, releaseName string, monitor *upgradePodMonitor, atomic bool, helmErr error, debug bool) {
+	printDiagnosticsBanner("UPGRADE FAILED — DIAGNOSTICS")
+
+	if helmErr != nil {
+		printDiagnosticsSubSection("Helm Error")
+		pterm.Error.Println(helmErr.Error())
+	}
+
+	if atomic {
+		printDiagnosticsSubSection("Rollback Notice")
+		pterm.Warning.Println("Atomic rollback may have removed failed pods from the cluster.")
+		pterm.Warning.Println("Showing captured pod state and logs collected during the upgrade.")
+	}
+
+	clientset, err := getKubeClient()
+	if err != nil {
+		pterm.Error.Printf("Could not connect to cluster for diagnostics: %v\n", err)
+		return
+	}
+
+	snapshots := monitor.failedSnapshots()
+	if len(snapshots) > 0 {
+		printDiagnosticsSubSection(fmt.Sprintf("Failed Pods During Rollout (%d)", len(snapshots)))
+		for i, pod := range snapshots {
+			printFailedPodReport(clientset, namespace, *pod, i+1, len(snapshots))
+		}
+	}
+
+	printDeploymentRolloutStatus(clientset, namespace, releaseName)
+
+	if len(snapshots) == 0 {
+		printDiagnosticsSubSection("Failed Resource Details")
+		describeFailedResources(namespace, releaseName)
+	}
+
+	printDiagnosticsSubSection("Release Resources")
+	printReleaseResources(namespace, releaseName)
+
+	if len(snapshots) == 0 {
+		printDiagnosticsSubSection("Current Pod Status")
+		pterm.Warning.Println("No failed pod snapshots were captured during the upgrade window.")
+		if err := printFinalPodStatus(namespace, releaseName, debug); err != nil {
+			pterm.Warning.Printf("Current pod status: %v\n", err)
+		}
+
+		// Try live failed pods and fetch kubectl-style logs
+		livePods, listErr := getPods(namespace, releaseName)
+		if listErr == nil {
+			for _, pod := range livePods {
+				if isPodUnhealthyForUpgrade(&pod) {
+					printFailedPodReport(clientset, namespace, pod, 1, 1)
+				}
+			}
+		}
+	}
+
+	fmt.Println()
+	fmt.Println(strings.Repeat("═", 80))
+}
+
+func printDeploymentRolloutStatus(clientset *kubernetes.Clientset, namespace, releaseName string) {
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf(appKubernets, releaseName),
+	})
+	if err != nil || len(deployments.Items) == 0 {
+		return
+	}
+
+	printDiagnosticsSubSection("Deployment Rollout Status")
+	for _, dep := range deployments.Items {
+		replicas := int32(0)
+		if dep.Spec.Replicas != nil {
+			replicas = *dep.Spec.Replicas
+		}
+		fmt.Printf("  %s\n", dep.Name)
+		fmt.Printf("    Ready     : %d/%d\n", dep.Status.ReadyReplicas, replicas)
+		fmt.Printf("    Updated   : %d\n", dep.Status.UpdatedReplicas)
+		fmt.Printf("    Available : %d\n", dep.Status.AvailableReplicas)
+
+		for _, cond := range dep.Status.Conditions {
+			if cond.Status != corev1.ConditionTrue && cond.Message != "" {
+				pterm.Warning.Printf("    Condition : %s (%s) — %s\n", cond.Type, cond.Reason, cond.Message)
+			}
+		}
+
+		events, evtErr := clientset.CoreV1().Events(namespace).List(context.Background(), metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Deployment", dep.Name),
+		})
+		if evtErr == nil && len(events.Items) > 0 {
+			limit := len(events.Items)
+			if limit > 5 {
+				limit = 5
+			}
+			fmt.Printf("    Recent events:\n")
+			for i := 0; i < limit; i++ {
+				evt := events.Items[i]
+				prefix := "      ℹ"
+				if evt.Type == "Warning" {
+					prefix = "      ⚠"
+				}
+				fmt.Printf("%s  [%s] %s\n", prefix, evt.Reason, evt.Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implemented improvements to smurf selm logging to provide better diagnostics when deployments fail, especially when using atomic Helm deployments.
---

## Changes
- Added support for collecting logs from pods that terminate during failed deployments.
- Captured logs even when failed pods are no longer running or visible after rollback.
- Improved failure diagnostics for deployments using the --atomic flag.
- Enhanced debugging by surfacing logs from terminated pods before they are cleaned up.
- Improved overall troubleshooting experience for deployment failures.


## Result

<img width="582" height="736" alt="Screenshot 2026-07-02 at 9 42 51 PM" src="https://github.com/user-attachments/assets/47b7e4be-a70e-437b-adb9-398b5145d7ed" />

