### PR TITLE
feat: fix Azure ACR image push tagging and support comma-separated --build-arg values

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -113,11 +113,9 @@ func prepareDockerBuild() (docker.BuildOptions, error) {
 		dockerfilePath = filepath.Join(contextDir, "Dockerfile")
 	}
 
-	buildArgs := make(map[string]string)
-	for _, arg := range configs.BuildArgs {
-		if parts := strings.SplitN(arg, "=", 2); len(parts) == 2 {
-			buildArgs[parts[0]] = parts[1]
-		}
+	buildArgs, err := configs.ParseBuildArgs(configs.BuildArgs)
+	if err != nil {
+		return docker.BuildOptions{}, fmt.Errorf("invalid build-arg: %w", err)
 	}
 
 	return docker.BuildOptions{

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -113,9 +113,9 @@ func prepareDockerBuild() (docker.BuildOptions, error) {
 		dockerfilePath = filepath.Join(contextDir, "Dockerfile")
 	}
 
-	buildArgs, err := configs.ParseBuildArgs(configs.BuildArgs)
+	buildArgs, err := configs.ParseCLIBuildArgs(configs.BuildArgs)
 	if err != nil {
-		return docker.BuildOptions{}, fmt.Errorf("invalid build-arg: %w", err)
+		return docker.BuildOptions{}, err
 	}
 
 	return docker.BuildOptions{

--- a/cmd/sdkr/build.go
+++ b/cmd/sdkr/build.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/clouddrove/smurf/configs"
@@ -59,12 +58,9 @@ var buildCmd = &cobra.Command{
 			}
 		}
 
-		buildArgsMap := make(map[string]string)
-		for _, arg := range configs.BuildArgs {
-			parts := strings.SplitN(arg, "=", 2)
-			if len(parts) == 2 {
-				buildArgsMap[parts[0]] = parts[1]
-			}
+		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		if err != nil {
+			return fmt.Errorf("invalid build-arg: %w", err)
 		}
 
 		if configs.ContextDir == "" {
@@ -97,7 +93,7 @@ var buildCmd = &cobra.Command{
 			BuildKit:       configs.BuildKit,
 		}
 
-		err := docker.Build(imageName, tag, opts, useAI)
+		err = docker.Build(imageName, tag, opts, useAI)
 		if err != nil {
 			return err
 		}
@@ -105,7 +101,7 @@ var buildCmd = &cobra.Command{
 	},
 	Example: `
 smurf sdkr build my-image:v1
-smurf sdkr build my-image:v1 --file Dockerfile --context ./build-context --no-cache --build-arg key1=value1 --build-arg key2=value2 --target my-target --platform linux/amd64 --timeout 400
+smurf sdkr build my-image:v1 --file Dockerfile --context ./build-context --no-cache --build-arg key1=value1,key2=value2 --target my-target --platform linux/amd64 --timeout 400
 smurf sdkr build
 # In the last example, it will read "image:v1" from config and use the parsed image name and tag
 `,
@@ -115,7 +111,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "Path to Dockerfile relative to context directory")
 	buildCmd.Flags().StringVar(&configs.ContextDir, "context", "", "Build context directory (default: current directory)")
 	buildCmd.Flags().BoolVar(&configs.NoCache, "no-cache", false, "Do not use cache when building the image")
-	buildCmd.Flags().StringArrayVar(&configs.BuildArgs, "build-arg", []string{}, "Set build-time variables")
+	buildCmd.Flags().StringArrayVar(&configs.BuildArgs, "build-arg", []string{}, "Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs")
 	buildCmd.Flags().StringVar(&configs.Target, "target", "", "Set the target build stage to build")
 	buildCmd.Flags().StringVar(&configs.Platform, "platform", "", "Set the platform for the build (e.g., linux/amd64, linux/arm64)")
 	buildCmd.Flags().IntVar(&configs.BuildTimeout, "timeout", 1500, "Set the build timeout in seconds")

--- a/cmd/sdkr/build.go
+++ b/cmd/sdkr/build.go
@@ -58,9 +58,9 @@ var buildCmd = &cobra.Command{
 			}
 		}
 
-		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		buildArgsMap, err := sdkrBuildArgs()
 		if err != nil {
-			return fmt.Errorf("invalid build-arg: %w", err)
+			return err
 		}
 
 		if configs.ContextDir == "" {

--- a/cmd/sdkr/buildargs.go
+++ b/cmd/sdkr/buildargs.go
@@ -1,0 +1,11 @@
+package sdkr
+
+import "github.com/clouddrove/smurf/configs"
+
+func sdkrBuildArgs() (map[string]string, error) {
+	return configs.ParseCLIBuildArgs(configs.BuildArgs)
+}
+
+func buildArgsFrom(args []string) (map[string]string, error) {
+	return configs.ParseCLIBuildArgs(args)
+}

--- a/cmd/sdkr/provisionAcr.go
+++ b/cmd/sdkr/provisionAcr.go
@@ -56,9 +56,9 @@ var provisionAcrCmd = &cobra.Command{
 
 		fullAcrImage := fmt.Sprintf("%s.azurecr.io/%s", configs.RegistryName, imageRef)
 
-		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		buildArgsMap, err := sdkrBuildArgs()
 		if err != nil {
-			return fmt.Errorf("invalid build-arg: %w", err)
+			return err
 		}
 
 		if configs.ContextDir == "" {
@@ -87,14 +87,10 @@ var provisionAcrCmd = &cobra.Command{
 		}
 
 		pterm.Info.Println("Starting ACR build...")
-		localImageName, localTag, parseErr := configs.ParseImage(imageRef)
+		localImage, localImageName, localTag, parseErr := configs.NormalizeAcrLocalImage(imageRef)
 		if parseErr != nil {
 			pterm.Error.Println("Image Parse Err:", parseErr)
 			return parseErr
-		}
-
-		if localTag == "" {
-			localTag = "latest"
 		}
 
 		if err := docker.Build(localImageName, localTag, buildOpts, useAI); err != nil {
@@ -111,8 +107,6 @@ var provisionAcrCmd = &cobra.Command{
 			return err
 		}
 
-		localImage := fmt.Sprintf("%s:%s", localImageName, localTag)
-
 		pterm.Info.Printf("Pushing image %s to ACR...\n", pushImage)
 		if err := docker.PushImageToACR(
 			configs.SubscriptionID,
@@ -127,12 +121,12 @@ var provisionAcrCmd = &cobra.Command{
 		pterm.Success.Println("Push to ACR completed successfully.")
 
 		if configs.DeleteAfterPush {
-			pterm.Info.Printf("Deleting local image %s...\n", fullAcrImage)
-			if err := docker.RemoveImage(fullAcrImage, useAI); err != nil {
+			pterm.Info.Printf("Deleting local image %s...\n", localImage)
+			if err := docker.RemoveImage(localImage, useAI); err != nil {
 				pterm.Error.Println("Failed to delete local image:", err)
 				return fmt.Errorf("failed to delete local image: %v", err)
 			}
-			pterm.Success.Println("Successfully deleted local image:", fullAcrImage)
+			pterm.Success.Println("Successfully deleted local image:", localImage)
 		}
 
 		pterm.Success.Println("ACR provisioning completed successfully.")

--- a/cmd/sdkr/provisionAcr.go
+++ b/cmd/sdkr/provisionAcr.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/clouddrove/smurf/configs"
@@ -57,12 +56,9 @@ var provisionAcrCmd = &cobra.Command{
 
 		fullAcrImage := fmt.Sprintf("%s.azurecr.io/%s", configs.RegistryName, imageRef)
 
-		buildArgsMap := make(map[string]string)
-		for _, arg := range configs.BuildArgs {
-			parts := strings.SplitN(arg, "=", 2)
-			if len(parts) == 2 {
-				buildArgsMap[parts[0]] = parts[1]
-			}
+		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		if err != nil {
+			return fmt.Errorf("invalid build-arg: %w", err)
 		}
 
 		if configs.ContextDir == "" {
@@ -115,12 +111,14 @@ var provisionAcrCmd = &cobra.Command{
 			return err
 		}
 
+		localImage := fmt.Sprintf("%s:%s", localImageName, localTag)
+
 		pterm.Info.Printf("Pushing image %s to ACR...\n", pushImage)
 		if err := docker.PushImageToACR(
 			configs.SubscriptionID,
 			configs.ResourceGroup,
 			configs.RegistryName,
-			localImageName,
+			localImage,
 			useAI,
 		); err != nil {
 			pterm.Error.Println("Push to ACR failed:", err)
@@ -153,7 +151,7 @@ func init() {
 
 	provisionAcrCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "path to Dockerfile relative to context directory")
 	provisionAcrCmd.Flags().BoolVarP(&configs.NoCache, "no-cache", "c", false, "Do not use cache when building the image")
-	provisionAcrCmd.Flags().StringArrayVarP(&configs.BuildArgs, "build-arg", "a", []string{}, "Set build-time variables")
+	provisionAcrCmd.Flags().StringArrayVarP(&configs.BuildArgs, "build-arg", "a", []string{}, "Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs")
 	provisionAcrCmd.Flags().StringVarP(&configs.Target, "target", "t", "", "Set the target build stage to build")
 	provisionAcrCmd.Flags().StringVarP(&configs.Platform, "platform", "p", "", "Platform for the image")
 	provisionAcrCmd.Flags().StringVar(&configs.ContextDir, "context", "", "Build context directory (default: current directory)")

--- a/cmd/sdkr/provisionEcr.go
+++ b/cmd/sdkr/provisionEcr.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/clouddrove/smurf/configs"
@@ -64,12 +63,9 @@ var provisionEcrCmd = &cobra.Command{
 			ecrImageTag,
 		)
 
-		buildArgsMap := make(map[string]string)
-		for _, arg := range configs.BuildArgs {
-			parts := strings.SplitN(arg, "=", 2)
-			if len(parts) == 2 {
-				buildArgsMap[parts[0]] = parts[1]
-			}
+		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		if err != nil {
+			return fmt.Errorf("invalid build-arg: %w", err)
 		}
 
 		if configs.ContextDir == "" {
@@ -131,8 +127,7 @@ var provisionEcrCmd = &cobra.Command{
   #   123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:python
   smurf sdkr provision-ecr 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:python \
       --no-cache \
-      --build-arg key1=value1 \
-      --build-arg key2=value2 \
+      --build-arg key1=value1,key2=value2 \
       --target my-target \
       --platform linux/amd64 \
       --yes \
@@ -143,7 +138,7 @@ var provisionEcrCmd = &cobra.Command{
 func init() {
 	provisionEcrCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "Dockerfile path relative to context directory (default: 'Dockerfile')")
 	provisionEcrCmd.Flags().BoolVarP(&configs.NoCache, "no-cache", "c", false, "Do not use cache when building the image")
-	provisionEcrCmd.Flags().StringArrayVarP(&configs.BuildArgs, "build-arg", "a", []string{}, "Set build-time variables")
+	provisionEcrCmd.Flags().StringArrayVarP(&configs.BuildArgs, "build-arg", "a", []string{}, "Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs")
 	provisionEcrCmd.Flags().StringVarP(&configs.Target, "target", "t", "", "Set the target build stage to build")
 	provisionEcrCmd.Flags().StringVarP(&configs.Platform, "platform", "p", "", "Platform for the image")
 

--- a/cmd/sdkr/provisionEcr.go
+++ b/cmd/sdkr/provisionEcr.go
@@ -63,9 +63,9 @@ var provisionEcrCmd = &cobra.Command{
 			ecrImageTag,
 		)
 
-		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		buildArgsMap, err := sdkrBuildArgs()
 		if err != nil {
-			return fmt.Errorf("invalid build-arg: %w", err)
+			return err
 		}
 
 		if configs.ContextDir == "" {

--- a/cmd/sdkr/provisionGHCR.go
+++ b/cmd/sdkr/provisionGHCR.go
@@ -211,9 +211,9 @@ func prepareBuildOptions() (docker.BuildOptions, error) {
 		configs.DockerfilePath = filepath.Join(configs.ContextDir, configs.DockerfilePath)
 	}
 
-	buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+	buildArgsMap, err := sdkrBuildArgs()
 	if err != nil {
-		return docker.BuildOptions{}, fmt.Errorf("invalid build-arg: %w", err)
+		return docker.BuildOptions{}, err
 	}
 
 	return docker.BuildOptions{

--- a/cmd/sdkr/provisionGHCR.go
+++ b/cmd/sdkr/provisionGHCR.go
@@ -55,7 +55,7 @@ Example: ghcr.io/my-org/my-app:latest`,
 func init() {
 	provisionGHCRCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "Path to Dockerfile (default: Dockerfile)")
 	provisionGHCRCmd.Flags().BoolVar(&configs.NoCache, "no-cache", false, "Disable build cache")
-	provisionGHCRCmd.Flags().StringArrayVar(&configs.BuildArgs, "build-arg", []string{}, "Build-time variables (e.g. --build-arg key=value)")
+	provisionGHCRCmd.Flags().StringArrayVar(&configs.BuildArgs, "build-arg", []string{}, "Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs")
 	provisionGHCRCmd.Flags().StringVar(&configs.Target, "target", "", "Target build stage")
 	provisionGHCRCmd.Flags().StringVar(&configs.Platform, "platform", "", "Platform (e.g. linux/amd64)")
 	provisionGHCRCmd.Flags().IntVar(&configs.BuildTimeout, "timeout", 1500, "Build timeout in seconds")
@@ -211,12 +211,9 @@ func prepareBuildOptions() (docker.BuildOptions, error) {
 		configs.DockerfilePath = filepath.Join(configs.ContextDir, configs.DockerfilePath)
 	}
 
-	buildArgsMap := make(map[string]string)
-	for _, arg := range configs.BuildArgs {
-		parts := strings.SplitN(arg, "=", 2)
-		if len(parts) == 2 {
-			buildArgsMap[parts[0]] = parts[1]
-		}
+	buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+	if err != nil {
+		return docker.BuildOptions{}, fmt.Errorf("invalid build-arg: %w", err)
 	}
 
 	return docker.BuildOptions{

--- a/cmd/sdkr/provisionGcp.go
+++ b/cmd/sdkr/provisionGcp.go
@@ -187,7 +187,7 @@ func NewBuildConfig() *BuildConfig {
 }
 
 // PrepareBuildOptions prepares docker build options from configuration
-func (bc *BuildConfig) PrepareBuildOptions() docker.BuildOptions {
+func (bc *BuildConfig) PrepareBuildOptions() (docker.BuildOptions, error) {
 	// Set Dockerfile path
 	dockerfilePath := bc.DockerfilePath
 	if dockerfilePath == "" {
@@ -196,13 +196,9 @@ func (bc *BuildConfig) PrepareBuildOptions() docker.BuildOptions {
 		dockerfilePath = filepath.Join(bc.ContextDir, dockerfilePath)
 	}
 
-	// Parse build args
-	buildArgsMap := make(map[string]string)
-	for _, arg := range bc.BuildArgs {
-		parts := strings.SplitN(arg, "=", 2)
-		if len(parts) == 2 {
-			buildArgsMap[parts[0]] = parts[1]
-		}
+	buildArgsMap, err := configs.ParseBuildArgs(bc.BuildArgs)
+	if err != nil {
+		return docker.BuildOptions{}, fmt.Errorf("invalid build-arg: %w", err)
 	}
 
 	return docker.BuildOptions{
@@ -213,7 +209,7 @@ func (bc *BuildConfig) PrepareBuildOptions() docker.BuildOptions {
 		Target:         bc.Target,
 		Platform:       bc.Platform,
 		Timeout:        time.Duration(bc.Timeout) * time.Second,
-	}
+	}, nil
 }
 
 // loadConfiguration loads configuration from file or environment
@@ -325,7 +321,10 @@ Supports:
 		buildConfig.Platform = configs.Platform
 		buildConfig.Timeout = configs.BuildTimeout
 
-		buildOpts := buildConfig.PrepareBuildOptions()
+		buildOpts, err := buildConfig.PrepareBuildOptions()
+		if err != nil {
+			return err
+		}
 
 		// Build Docker image
 		pterm.Info.Println("Starting Docker build...")
@@ -388,7 +387,7 @@ Supports:
 
   # With additional options
   smurf sdkr provision-gcp myapp:v1.0 --project-id my-project --file Dockerfile --no-cache \
-    --build-arg key1=value1 --build-arg key2=value2 --target my-target \
+    --build-arg key1=value1,key2=value2 --target my-target \
     --delete --platform linux/amd64
 `,
 }
@@ -401,7 +400,7 @@ func init() {
 	// Build configuration flags
 	provisionGcpCmd.Flags().StringVarP(&configs.DockerfilePath, "file", "f", "", "Name of the Dockerfile relative to the context directory (default: 'Dockerfile')")
 	provisionGcpCmd.Flags().BoolVarP(&configs.NoCache, "no-cache", "c", false, "Do not use cache when building the image")
-	provisionGcpCmd.Flags().StringArrayVarP(&configs.BuildArgs, "build-arg", "a", []string{}, "Set build-time variables (e.g. --build-arg key=value)")
+	provisionGcpCmd.Flags().StringArrayVarP(&configs.BuildArgs, "build-arg", "a", []string{}, "Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs")
 	provisionGcpCmd.Flags().StringVarP(&configs.Target, "target", "t", "", "Set the target build stage to build")
 	provisionGcpCmd.Flags().StringVarP(&configs.Platform, "platform", "p", "", "Set the platform for the image (e.g., linux/amd64)")
 	provisionGcpCmd.Flags().StringVar(&configs.ContextDir, "context", "", "Build context directory (default: current directory)")

--- a/cmd/sdkr/provisionGcp.go
+++ b/cmd/sdkr/provisionGcp.go
@@ -196,9 +196,9 @@ func (bc *BuildConfig) PrepareBuildOptions() (docker.BuildOptions, error) {
 		dockerfilePath = filepath.Join(bc.ContextDir, dockerfilePath)
 	}
 
-	buildArgsMap, err := configs.ParseBuildArgs(bc.BuildArgs)
+	buildArgsMap, err := buildArgsFrom(bc.BuildArgs)
 	if err != nil {
-		return docker.BuildOptions{}, fmt.Errorf("invalid build-arg: %w", err)
+		return docker.BuildOptions{}, err
 	}
 
 	return docker.BuildOptions{

--- a/cmd/sdkr/provisionHub.go
+++ b/cmd/sdkr/provisionHub.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/clouddrove/smurf/configs"
@@ -78,12 +77,9 @@ var provisionHubCmd = &cobra.Command{
 
 		fullImageName := fmt.Sprintf("%s:%s", localImageName, localTag)
 
-		buildArgsMap := make(map[string]string)
-		for _, arg := range configs.BuildArgs {
-			parts := strings.SplitN(arg, "=", 2)
-			if len(parts) == 2 {
-				buildArgsMap[parts[0]] = parts[1]
-			}
+		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		if err != nil {
+			return fmt.Errorf("invalid build-arg: %w", err)
 		}
 
 		if configs.ContextDir == "" {
@@ -146,7 +142,7 @@ var provisionHubCmd = &cobra.Command{
 	Example: `
   # Provide "myuser/myimage:latest" as an argument
   smurf sdkr provision-hub myuser/myimage:latest --context . --file Dockerfile --no-cache \
-    --build-arg key1=value1 --build-arg key2=value2 --target my-target --platform linux/amd64 \
+    --build-arg key1=value1,key2=value2 --target my-target --platform linux/amd64 \
     --yes --delete
 
   # If you omit the argument, it will read from config and rely on "image_name" from there
@@ -171,7 +167,7 @@ func init() {
 		&configs.BuildArgs,
 		"build-arg",
 		[]string{},
-		"Set build-time variables (e.g. --build-arg key=value)",
+		"Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs",
 	)
 	provisionHubCmd.Flags().StringVar(
 		&configs.Target,

--- a/cmd/sdkr/provisionHub.go
+++ b/cmd/sdkr/provisionHub.go
@@ -77,9 +77,9 @@ var provisionHubCmd = &cobra.Command{
 
 		fullImageName := fmt.Sprintf("%s:%s", localImageName, localTag)
 
-		buildArgsMap, err := configs.ParseBuildArgs(configs.BuildArgs)
+		buildArgsMap, err := sdkrBuildArgs()
 		if err != nil {
-			return fmt.Errorf("invalid build-arg: %w", err)
+			return err
 		}
 
 		if configs.ContextDir == "" {

--- a/cmd/sdkr/pushACR.go
+++ b/cmd/sdkr/pushACR.go
@@ -45,38 +45,35 @@ var pushAcrCmd = &cobra.Command{
 			}
 		}
 
-		repoName, tag, parseErr := configs.ParseImage(imageRef)
+		localImage, repository, tag, parseErr := configs.NormalizeAcrLocalImage(imageRef)
 		if parseErr != nil {
 			pterm.Error.Printfln("invalid image format: %v", parseErr)
 			return fmt.Errorf("invalid image format: %v", parseErr)
 		}
-		if repoName == "" {
+		if repository == "" {
 			return errors.New("invalid image reference")
 		}
-		if tag == "" {
-			tag = "latest"
-		}
 
-		if configs.SubscriptionID == "" || configs.ResourceGroup == "" || configs.RegistryName == "" || repoName == "" {
+		if configs.SubscriptionID == "" || configs.ResourceGroup == "" || configs.RegistryName == "" {
 			pterm.Error.Println("Required flags are missing. Please provide the required flags.")
 			return errors.New("missing required ACR parameters")
 		}
 
-		acrImage := fmt.Sprintf("%s.azurecr.io/%s:%s", configs.RegistryName, repoName, tag)
+		acrImage := fmt.Sprintf("%s.azurecr.io/%s:%s", configs.RegistryName, repository, tag)
 
 		pterm.Info.Println("Pushing image to Azure Container Registry...")
-		if err := docker.PushImageToACR(configs.SubscriptionID, configs.ResourceGroup, configs.RegistryName, repoName, useAI); err != nil {
+		if err := docker.PushImageToACR(configs.SubscriptionID, configs.ResourceGroup, configs.RegistryName, localImage, useAI); err != nil {
 			pterm.Error.Println("Failed to push image:", err)
 			return err
 		}
 		pterm.Success.Println("Successfully pushed image to ACR:", acrImage)
 
 		if configs.DeleteAfterPush {
-			pterm.Info.Printf("Deleting local image %s...\n", repoName)
-			if err := docker.RemoveImage(repoName, useAI); err != nil {
+			pterm.Info.Printf("Deleting local image %s...\n", localImage)
+			if err := docker.RemoveImage(localImage, useAI); err != nil {
 				return err
 			}
-			pterm.Success.Println("Successfully deleted local image:", repoName)
+			pterm.Success.Println("Successfully deleted local image:", localImage)
 		}
 
 		return nil

--- a/configs/common.go
+++ b/configs/common.go
@@ -19,6 +19,34 @@ func ParseImage(image string) (string, string, error) {
 	return image, "latest", nil
 }
 
+// StripAcrRegistryHost removes an optional ACR hostname from a repository path.
+// For example, "myregistry.azurecr.io/my-app" becomes "my-app".
+func StripAcrRegistryHost(repository string) string {
+	if !strings.Contains(repository, "/") {
+		return repository
+	}
+	parts := strings.SplitN(repository, "/", 2)
+	if strings.HasSuffix(parts[0], ".azurecr.io") {
+		return parts[1]
+	}
+	return repository
+}
+
+// NormalizeAcrLocalImage converts an image reference to the local Docker image name.
+// Full ACR references such as "registry.azurecr.io/my-app:v1" are normalized to "my-app:v1".
+func NormalizeAcrLocalImage(imageRef string) (localImage, repository, tag string, err error) {
+	repository, tag, err = ParseImage(imageRef)
+	if err != nil {
+		return "", "", "", err
+	}
+	if tag == "" {
+		tag = "latest"
+	}
+	repository = StripAcrRegistryHost(repository)
+	localImage = fmt.Sprintf("%s:%s", repository, tag)
+	return localImage, repository, tag, nil
+}
+
 // ParseEcrImageRef parses an ECR image reference into its account ID, region, repository, and tag components.
 // It returns accountID, region, repository, tag, error
 func ParseEcrImageRef(imageRef string) (string, string, string, string, error) {
@@ -54,6 +82,74 @@ func ParseEcrImageRef(imageRef string) (string, string, string, string, error) {
 
 	pterm.Info.Printfln("Successfuly parse ECR image referance...")
 	return accountID, region, repository, tag, nil
+}
+
+// ParseBuildArgs converts CLI --build-arg values into a key/value map.
+// Each flag value can be a single key=value pair or comma-separated pairs:
+// --build-arg NODE_ENV=production,API_URL=https://example.com
+// Repeated flags are also supported and later values override earlier ones.
+func ParseBuildArgs(args []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, raw := range args {
+		for _, entry := range splitBuildArgEntries(raw) {
+			parts := strings.SplitN(entry, "=", 2)
+			if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" {
+				return nil, fmt.Errorf("invalid build-arg %q: expected key=value", entry)
+			}
+			result[strings.TrimSpace(parts[0])] = parts[1]
+		}
+	}
+	return result, nil
+}
+
+func splitBuildArgEntries(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if !strings.Contains(raw, ",") {
+		return []string{raw}
+	}
+
+	var entries []string
+	start := 0
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != ',' {
+			continue
+		}
+
+		next := strings.TrimSpace(raw[i+1:])
+		eq := strings.Index(next, "=")
+		if eq <= 0 {
+			continue
+		}
+		if !isBuildArgKey(strings.TrimSpace(next[:eq])) {
+			continue
+		}
+
+		entries = append(entries, strings.TrimSpace(raw[start:i]))
+		start = i + 1
+	}
+
+	entries = append(entries, strings.TrimSpace(raw[start:]))
+	return entries
+}
+
+func isBuildArgKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // SplitKeyValue splits a string into a key and value at the first occurrence of the

--- a/configs/common.go
+++ b/configs/common.go
@@ -47,6 +47,25 @@ func NormalizeAcrLocalImage(imageRef string) (localImage, repository, tag string
 	return localImage, repository, tag, nil
 }
 
+// AcrImageReferences returns the local Docker source and remote ACR target for tagging.
+func AcrImageReferences(imageName, loginServer string) (localSource, remoteImage string, err error) {
+	localSource, repository, tag, err := NormalizeAcrLocalImage(imageName)
+	if err != nil {
+		return "", "", err
+	}
+	remoteImage = fmt.Sprintf("%s/%s:%s", loginServer, repository, tag)
+	return localSource, remoteImage, nil
+}
+
+// ParseCLIBuildArgs parses SDKR --build-arg flags and returns a user-facing error on failure.
+func ParseCLIBuildArgs(args []string) (map[string]string, error) {
+	buildArgs, err := ParseBuildArgs(args)
+	if err != nil {
+		return nil, fmt.Errorf("invalid build-arg: %w", err)
+	}
+	return buildArgs, nil
+}
+
 // ParseEcrImageRef parses an ECR image reference into its account ID, region, repository, and tag components.
 // It returns accountID, region, repository, tag, error
 func ParseEcrImageRef(imageRef string) (string, string, string, string, error) {

--- a/configs/common_buildargs_test.go
+++ b/configs/common_buildargs_test.go
@@ -71,3 +71,46 @@ func TestParseBuildArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestAcrImageReferences(t *testing.T) {
+	t.Parallel()
+
+	localSource, remoteImage, err := AcrImageReferences("react-test:latest", "testacr1234.azurecr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if localSource != "react-test:latest" {
+		t.Fatalf("local source: got %q, want react-test:latest", localSource)
+	}
+	if remoteImage != "testacr1234.azurecr.io/react-test:latest" {
+		t.Fatalf("remote image: got %q, want testacr1234.azurecr.io/react-test:latest", remoteImage)
+	}
+
+	localSource, remoteImage, err = AcrImageReferences("testacr1234.azurecr.io/react-test:latest", "testacr1234.azurecr.io")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if localSource != "react-test:latest" {
+		t.Fatalf("normalized local source: got %q, want react-test:latest", localSource)
+	}
+	if remoteImage != "testacr1234.azurecr.io/react-test:latest" {
+		t.Fatalf("remote image: got %q", remoteImage)
+	}
+}
+
+func TestParseCLIBuildArgs(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParseCLIBuildArgs([]string{"NODE_ENV=production,API_URL=https://example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["NODE_ENV"] != "production" || got["API_URL"] != "https://example.com" {
+		t.Fatalf("unexpected map: %v", got)
+	}
+
+	_, err = ParseCLIBuildArgs([]string{"invalid"})
+	if err == nil {
+		t.Fatal("expected invalid build-arg error")
+	}
+}

--- a/configs/common_buildargs_test.go
+++ b/configs/common_buildargs_test.go
@@ -1,0 +1,73 @@
+package configs
+
+import "testing"
+
+func TestParseBuildArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "single pair",
+			args: []string{"NODE_ENV=production"},
+			want: map[string]string{"NODE_ENV": "production"},
+		},
+		{
+			name: "comma separated in one flag",
+			args: []string{"NODE_ENV=production,API_URL=https://example.com"},
+			want: map[string]string{
+				"NODE_ENV": "production",
+				"API_URL":  "https://example.com",
+			},
+		},
+		{
+			name: "repeated flags",
+			args: []string{"FOO=bar", "BAZ=qux"},
+			want: map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name: "later flag overrides earlier",
+			args: []string{"FOO=bar", "FOO=baz"},
+			want: map[string]string{"FOO": "baz"},
+		},
+		{
+			name: "value with comma stays intact",
+			args: []string{"MESSAGE=hello,world"},
+			want: map[string]string{"MESSAGE": "hello,world"},
+		},
+		{
+			name:    "invalid entry",
+			args:    []string{"not-a-build-arg"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseBuildArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for key, wantVal := range tt.want {
+				if gotVal, ok := got[key]; !ok || gotVal != wantVal {
+					t.Fatalf("key %q: got %q, want %q", key, gotVal, wantVal)
+				}
+			}
+		})
+	}
+}

--- a/docs/sm/docs/cli/smurf_sdkr_build.md
+++ b/docs/sm/docs/cli/smurf_sdkr_build.md
@@ -11,7 +11,7 @@ smurf sdkr build [IMAGE[:TAG]] [flags]
 ```
 
 smurf sdkr build my-image:v1
-smurf sdkr build my-image:v1 --file Dockerfile --context ./build-context --no-cache --build-arg key1=value1 --build-arg key2=value2 --target my-target --platform linux/amd64 --timeout 400
+smurf sdkr build my-image:v1 --file Dockerfile --context ./build-context --no-cache --build-arg key1=value1,key2=value2 --target my-target --platform linux/amd64 --timeout 400
 smurf sdkr build
 # In the last example, it will read "image:v1" from config and use the parsed image name and tag
 
@@ -21,7 +21,7 @@ smurf sdkr build
 
 ```
       --ai                      To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.
-      --build-arg stringArray   Set build-time variables
+      --build-arg stringArray   Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs
       --buildkit                Enable BuildKit for advanced Dockerfile features
       --context string          Build context directory (default: current directory)
   -f, --file string             Path to Dockerfile relative to context directory

--- a/docs/sm/docs/cli/smurf_sdkr_provision-acr.md
+++ b/docs/sm/docs/cli/smurf_sdkr_provision-acr.md
@@ -19,7 +19,7 @@ smurf sdkr provision-acr [IMAGE_NAME[:TAG]] [flags]
 
 ```
       --ai                       To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.
-  -a, --build-arg stringArray    Set build-time variables
+  -a, --build-arg stringArray    Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs
       --context string           Build context directory (default: current directory)
   -d, --delete                   Delete the local image after pushing
   -f, --file string              path to Dockerfile relative to context directory

--- a/docs/sm/docs/cli/smurf_sdkr_provision-ecr.md
+++ b/docs/sm/docs/cli/smurf_sdkr_provision-ecr.md
@@ -14,8 +14,7 @@ smurf sdkr provision-ecr [IMAGE_NAME[:TAG]] [flags]
   #   123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:python
   smurf sdkr provision-ecr 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:python \
       --no-cache \
-      --build-arg key1=value1 \
-      --build-arg key2=value2 \
+      --build-arg key1=value1,key2=value2 \
       --target my-target \
       --platform linux/amd64 \
       --yes \
@@ -27,7 +26,7 @@ smurf sdkr provision-ecr [IMAGE_NAME[:TAG]] [flags]
 
 ```
       --ai                      To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.
-  -a, --build-arg stringArray   Set build-time variables
+  -a, --build-arg stringArray   Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs
       --context string          Build context directory (default: current directory)
   -d, --delete                  Delete the local image after pushing
   -f, --file string             Dockerfile path relative to context directory (default: 'Dockerfile')

--- a/docs/sm/docs/cli/smurf_sdkr_provision-gcp.md
+++ b/docs/sm/docs/cli/smurf_sdkr_provision-gcp.md
@@ -39,7 +39,7 @@ smurf sdkr provision-gcp [IMAGE_NAME[:TAG]] [flags]
 
   # With additional options
   smurf sdkr provision-gcp myapp:v1.0 --project-id my-project --file Dockerfile --no-cache \
-    --build-arg key1=value1 --build-arg key2=value2 --target my-target \
+    --build-arg key1=value1,key2=value2 --target my-target \
     --delete --platform linux/amd64
 
 ```
@@ -48,7 +48,7 @@ smurf sdkr provision-gcp [IMAGE_NAME[:TAG]] [flags]
 
 ```
       --ai                      To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.
-  -a, --build-arg stringArray   Set build-time variables (e.g. --build-arg key=value)
+  -a, --build-arg stringArray   Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs
       --context string          Build context directory (default: current directory)
   -d, --delete                  Delete the local image after pushing
   -f, --file string             Name of the Dockerfile relative to the context directory (default: 'Dockerfile')

--- a/docs/sm/docs/cli/smurf_sdkr_provision-ghcr.md
+++ b/docs/sm/docs/cli/smurf_sdkr_provision-ghcr.md
@@ -46,7 +46,7 @@ smurf sdkr provision-ghcr [IMAGE_NAME[:TAG]] [flags]
 
 ```
       --ai                      To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.
-      --build-arg stringArray   Build-time variables (e.g. --build-arg key=value)
+      --build-arg stringArray   Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs
       --context string          Build context (default: current directory)
   -d, --delete                  Delete local image after push
   -f, --file string             Path to Dockerfile (default: Dockerfile)

--- a/docs/sm/docs/cli/smurf_sdkr_provision-hub.md
+++ b/docs/sm/docs/cli/smurf_sdkr_provision-hub.md
@@ -19,7 +19,7 @@ smurf sdkr provision-hub [IMAGE_NAME[:TAG]] [flags]
 
   # Provide "myuser/myimage:latest" as an argument
   smurf sdkr provision-hub myuser/myimage:latest --context . --file Dockerfile --no-cache \
-    --build-arg key1=value1 --build-arg key2=value2 --target my-target --platform linux/amd64 \
+    --build-arg key1=value1,key2=value2 --target my-target --platform linux/amd64 \
     --yes --delete
 
   # If you omit the argument, it will read from config and rely on "image_name" from there
@@ -31,7 +31,7 @@ smurf sdkr provision-hub [IMAGE_NAME[:TAG]] [flags]
 
 ```
       --ai                      To enable AI help mode, export the OPENAI_API_KEY environment variable with your OpenAI API key.
-      --build-arg stringArray   Set build-time variables (e.g. --build-arg key=value)
+      --build-arg stringArray   Set build-time variables (key=value). Repeat the flag or pass comma-separated pairs
       --context string          Build context directory (default: current directory)
   -d, --delete                  Delete the local image after pushing
   -f, --file string             Dockerfile path relative to the context directory (default: 'Dockerfile')

--- a/internal/docker/pushAcr.go
+++ b/internal/docker/pushAcr.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
+	"github.com/clouddrove/smurf/configs"
 	"github.com/clouddrove/smurf/internal/ai"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
@@ -78,7 +78,12 @@ func PushImageToACR(subscriptionID, resourceGroupName, registryName, imageName s
 	spinner.Success("Docker client created\n")
 
 	spinner, _ = pterm.DefaultSpinner.Start("Tagging the image...")
-	localSource, taggedImage := acrImageReferences(imageName, loginServer)
+	localSource, taggedImage, err := configs.AcrImageReferences(imageName, loginServer)
+	if err != nil {
+		spinner.Fail("Failed to prepare image references\n")
+		ai.AIExplainError(useAI, err.Error())
+		return fmt.Errorf("failed to prepare image references : %v", err)
+	}
 	err = dockerClient.ImageTag(ctx, localSource, taggedImage)
 	if err != nil {
 		spinner.Fail("Failed to tag the image\n")
@@ -136,23 +141,4 @@ func PushImageToACR(subscriptionID, resourceGroupName, registryName, imageName s
 	pterm.Success.Printfln("Image pushed to ACR: %s\n", link)
 	pterm.Success.Printfln("Successfully pushed image '%s' to ACR '%s'\n", taggedImage, registryName)
 	return nil
-}
-
-func acrImageReferences(imageName, loginServer string) (localSource, taggedImage string) {
-	repository, tag := parseImageNameAndTag(imageName)
-	repository = stripAcrRegistryHost(repository)
-	localSource = fmt.Sprintf("%s:%s", repository, tag)
-	taggedImage = fmt.Sprintf("%s/%s:%s", loginServer, repository, tag)
-	return localSource, taggedImage
-}
-
-func stripAcrRegistryHost(repository string) string {
-	if !strings.Contains(repository, "/") {
-		return repository
-	}
-	parts := strings.SplitN(repository, "/", 2)
-	if strings.HasSuffix(parts[0], ".azurecr.io") {
-		return parts[1]
-	}
-	return repository
 }

--- a/internal/docker/pushAcr.go
+++ b/internal/docker/pushAcr.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry"
@@ -77,8 +78,8 @@ func PushImageToACR(subscriptionID, resourceGroupName, registryName, imageName s
 	spinner.Success("Docker client created\n")
 
 	spinner, _ = pterm.DefaultSpinner.Start("Tagging the image...")
-	taggedImage := fmt.Sprintf("%s/%s", loginServer, imageName)
-	err = dockerClient.ImageTag(ctx, imageName, taggedImage)
+	localSource, taggedImage := acrImageReferences(imageName, loginServer)
+	err = dockerClient.ImageTag(ctx, localSource, taggedImage)
 	if err != nil {
 		spinner.Fail("Failed to tag the image\n")
 		ai.AIExplainError(useAI, err.Error())
@@ -133,6 +134,25 @@ func PushImageToACR(subscriptionID, resourceGroupName, registryName, imageName s
 	spinner.Success("Image pushed to ACR\n")
 	link := fmt.Sprintf("https://%s.azurecr.io", registryName)
 	pterm.Success.Printfln("Image pushed to ACR: %s\n", link)
-	pterm.Success.Printfln("Successfully pushed image '%s' to ACR '%s'\n", imageName, registryName)
+	pterm.Success.Printfln("Successfully pushed image '%s' to ACR '%s'\n", taggedImage, registryName)
 	return nil
+}
+
+func acrImageReferences(imageName, loginServer string) (localSource, taggedImage string) {
+	repository, tag := parseImageNameAndTag(imageName)
+	repository = stripAcrRegistryHost(repository)
+	localSource = fmt.Sprintf("%s:%s", repository, tag)
+	taggedImage = fmt.Sprintf("%s/%s:%s", loginServer, repository, tag)
+	return localSource, taggedImage
+}
+
+func stripAcrRegistryHost(repository string) string {
+	if !strings.Contains(repository, "/") {
+		return repository
+	}
+	parts := strings.SplitN(repository, "/", 2)
+	if strings.HasSuffix(parts[0], ".azurecr.io") {
+		return parts[1]
+	}
+	return repository
 }

--- a/internal/docker/pushEcr.go
+++ b/internal/docker/pushEcr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/clouddrove/smurf/configs"
 	"github.com/clouddrove/smurf/internal/ai"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
@@ -166,7 +167,7 @@ func PushImageToECR(imageName, region, repositoryName string, useAI bool) error 
 	authStr := base64.URLEncoding.EncodeToString(encodedJSON)
 
 	// Tag image
-	_, tag := parseImageNameAndTag(imageName)
+	_, tag, _ := configs.ParseImage(imageName)
 	ecrImage := fmt.Sprintf("%s/%s:%s", ecrURL, repositoryName, tag)
 	if err := cli.ImageTag(ctx, imageName, ecrImage); err != nil {
 		logger.logError("Failed to tag image", err)
@@ -223,12 +224,4 @@ func PushImageToECR(imageName, region, repositoryName string, useAI bool) error 
 	}
 
 	return nil
-}
-
-func parseImageNameAndTag(imageName string) (string, string) {
-	parts := strings.Split(imageName, ":")
-	if len(parts) == 2 {
-		return parts[0], parts[1]
-	}
-	return imageName, "latest"
 }


### PR DESCRIPTION
## Summary

- Fix Azure ACR push failing with `No such image: <registry>.azurecr.io/<image>:latest` by tagging the correct local image and including the image tag in the push flow.
- Add support for passing multiple Docker build arguments in a single `--build-arg` flag using comma-separated `key=value` pairs.

## Changes

### Azure ACR push fix

- Normalize local image references in `configs/common.go` (`NormalizeAcrLocalImage`, `StripAcrRegistryHost`) so full ACR URLs like `myregistry.azurecr.io/my-app:latest` are treated as local `my-app:latest`.
- Update `internal/docker/pushAcr.go` to tag from the correct local source (`react-test:latest`) to the full ACR target (`registry.azurecr.io/react-test:latest`).
- Update `cmd/sdkr/pushACR.go` and `cmd/sdkr/provisionAcr.go` to pass the full local image reference (with tag) into `PushImageToACR`.

**Before:** Push attempted to tag a non-existent local image using the ACR registry URL.  
**After:** Push tags the locally built image and pushes it to ACR successfully.

### Multi `--build-arg` support

- Add `ParseBuildArgs()` in `configs/common.go` to parse:
  - repeated flags: `--build-arg FOO=bar --build-arg BAZ=qux`
  - comma-separated pairs: `--build-arg FOO=bar,BAZ=qux`
- Replace duplicated build-arg parsing across build/provision/deploy commands.
- Add unit tests in `configs/common_buildargs_test.go`.


## Test
  
### Azure ACR push fix
  
<img width="887" height="227" alt="Screenshot 2026-07-14 at 6 08 18 PM" src="https://github.com/user-attachments/assets/c436b1a7-9057-458a-80ff-0c69c3ddcc1b" />
<img width="864" height="290" alt="Screenshot 2026-07-14 at 6 08 28 PM" src="https://github.com/user-attachments/assets/458841ff-4fbe-4d9c-a4fd-74c33e26c35d" />


### Multi `--build-arg` support

https://github.com/clouddrove-sandbox/smurf-workflows/actions/runs/29332038000/job/87082056083
  
  
  
