### PR TITLE
fix(stf): exit non-zero when apply or destroy is declined

### DIFF
--- a/internal/terraform/apply.go
+++ b/internal/terraform/apply.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,23 @@ import (
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
 )
+
+// ErrOperationCancelled is returned when a user declines an interactive
+// approval prompt. Returning it (instead of nil) lets the error propagate to
+// RootCmd.Execute, so the CLI exits non-zero and scripts or CI can tell that
+// the operation was not carried out.
+var ErrOperationCancelled = errors.New("operation cancelled by user")
+
+// confirmApproval reports whether an operation may proceed. It returns nil when
+// approved (either pre-approved via --auto-approve or the user typed "yes"), and
+// ErrOperationCancelled when the user declined. ask is only invoked when the
+// operation was not pre-approved.
+func confirmApproval(approve bool, ask func() bool) error {
+	if approve || ask() {
+		return nil
+	}
+	return ErrOperationCancelled
+}
 
 func Apply(approve bool, vars []string,
 	varFiles []string, lock bool,
@@ -56,11 +74,9 @@ func Apply(approve bool, vars []string,
 	}
 
 	// Approval
-	if !approve {
-		if !askForApproval() {
-			Warn("Operation cancelled by user.")
-			return nil
-		}
+	if err := confirmApproval(approve, askForApproval); err != nil {
+		Warn("Operation cancelled by user.")
+		return err
 	}
 
 	// Apply

--- a/internal/terraform/apply_test.go
+++ b/internal/terraform/apply_test.go
@@ -1,0 +1,46 @@
+package terraform
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestConfirmApproval verifies the approval gate shared by apply and destroy:
+// a pre-approved run or an explicit "yes" proceeds (nil), while a declined
+// prompt returns ErrOperationCancelled so the CLI exits non-zero.
+func TestConfirmApproval(t *testing.T) {
+	cases := []struct {
+		name    string
+		approve bool
+		ask     func() bool
+		wantErr error
+	}{
+		{
+			name:    "auto-approve skips the prompt",
+			approve: true,
+			ask:     func() bool { t.Helper(); t.Error("ask must not be called when pre-approved"); return false },
+			wantErr: nil,
+		},
+		{
+			name:    "user approves",
+			approve: false,
+			ask:     func() bool { return true },
+			wantErr: nil,
+		},
+		{
+			name:    "user declines",
+			approve: false,
+			ask:     func() bool { return false },
+			wantErr: ErrOperationCancelled,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := confirmApproval(tc.approve, tc.ask)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("confirmApproval(%v) error = %v, want %v", tc.approve, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/terraform/destroy.go
+++ b/internal/terraform/destroy.go
@@ -87,16 +87,16 @@ func Destroy(approve bool, lock bool,
 	customWriter.Write([]byte(planDetail))
 
 	// Ask for confirmation if not auto-approved
-	if !approve {
+	ask := func() bool {
 		var confirmation string
 		fmt.Print("\nDo you want to destroy these resources? Only 'yes' will be accepted to approve.\nEnter a value: ")
 		fmt.Scanln(&confirmation)
 		fmt.Println()
-
-		if confirmation != "yes" {
-			Warn("Destroy operation aborted by user.")
-			return nil
-		}
+		return confirmation == "yes"
+	}
+	if err := confirmApproval(approve, ask); err != nil {
+		Warn("Destroy operation aborted by user.")
+		return err
 	}
 
 	tf.SetStdout(os.Stdout)


### PR DESCRIPTION
## Summary

`smurf stf apply` and `smurf stf destroy` returned exit code 0 when the user declined the interactive approval prompt, so scripts and CI could not tell that the operation was cancelled. They now return a non-zero exit code, matching Terraform's own behavior on a declined apply.

A shared `confirmApproval` helper and an `ErrOperationCancelled` sentinel are returned on decline; the sentinel propagates through `RunE` to `RootCmd.Execute`, which exits 1. The "no changes / no resources" success paths still return nil (exit 0), unchanged.

Note: `stf provision` chains `terraform.Apply`, so declining its prompt now aborts the chain (skips `output`) and exits non-zero instead of silently continuing. This is the intended behavior for a declined apply.

## Related issue

Closes #457

## How was this tested?

- [x] `make test` (all packages pass, including the new `TestConfirmApproval`)
- [x] `make vet`
- [x] `gofmt -l .` (no output)
- [ ] Integration tests (`make test-integration`, if applicable)

## Docs

- [ ] Updated `docs/{sm,sdkr,selm,stf}/` or `CONTRIBUTING.md` if user-facing behavior changed

## Checklist

- [x] Commit subjects follow conventional commits (`fix(stf): ...`)
- [x] `cmd/` contains no business logic; logic lives in `internal/`
- [x] PR is focused; unrelated changes are split out
