### PR TITLE
ci: harden pr-validation token scope and compile-check integration tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,4 +11,11 @@ on:
 jobs:
   pr-validation:
     if: github.actor != 'dependabot[bot]'
+    # Least privilege for the reusable workflow: it only checks out the repo,
+    # reads PR labels and lints commit messages. Without this the job would
+    # inherit the repository default token, which is write-scoped.
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
     uses: clouddrove/github-shared-workflows/.github/workflows/pr-checks.yml@b12c03fd682c618813721af75a5f681adb2ae921

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,12 @@ test:
 test-integration:
 	go test -tags=integration -v ./test/...
 
+# Vet the main tree, then compile-check the integration tests too. They sit
+# behind the `integration` build tag, so `go vet ./...` and `go test ./...`
+# skip them entirely and a dependency bump could break them unnoticed.
 vet:
 	go vet ./...
+	go vet -tags=integration ./test/...
 
 # Regenerate the CLI reference under docs/sm/docs/cli from the live command
 # tree, so it can never drift from the code. Depends on compile (not


### PR DESCRIPTION
Two independent CI fixes surfaced while reviewing the dependabot queue (#496, #498, #499, #500). Neither is caused by those PRs; both are pre-existing.

## 1. `pr-validation` ran with a write-scoped token

`.github/workflows/pr-checks.yml` calls the shared `pr-checks.yml` reusable workflow with no `permissions:` block, so the job inherited the repository default. That default is `default_workflow_permissions: write` with `can_approve_pull_request_reviews: true`.

The upstream workflow also interpolates `\${{ github.event.pull_request.title }}` directly into a `run` block. Fork PRs are not exposed (the `pull_request` trigger gives forks a read-only token and no secrets), but a same-repo branch is: an attacker-controlled PR title reaches a shell in a job holding a write token that can approve reviews.

The reusable workflow only checks out the repo, reads PR labels via `/issues/{n}/labels`, and runs commitlint. It needs `contents: read`, `pull-requests: read`, `issues: read` and nothing else, so that is what it now gets.

## 2. Integration tests were never compiled by CI

Every file under `test/{docker,helm,terraform}` is behind `//go:build integration`. Verified on master:

```
$ go list ./test/...
go: warning: "./test/..." matched no packages
```

So `make test` (`go test ./...`) and `make vet` (`go vet ./...`) both skip that code entirely, and CI's "Build and Test" job has never compiled it. A dependency bump could break those tests with every check still green.

`make vet` now also runs `go vet -tags=integration ./test/...`, which matches all 3 packages and type-checks them. Vet compiles but does not run, so this needs no docker, helm or terraform on the runner and adds no flakiness. `make test-integration` is unchanged and still the way to actually execute them.

Confirmed the new step fails on real breakage rather than passing vacuously: injecting an undefined symbol into `test/docker/tag_test.go` produces `vet: test/docker/tag_test.go:65:9: undefined: undefinedSymbolXYZ`.

## Verification

`make vet` passes on this branch. `go build ./...` and `go test ./...` unaffected.