### PR TITLE
ci: pin all actions to commit SHAs and scope workflow tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,17 +10,22 @@ on:
       - "**"
   pull_request:
 
+# Build and test only read the repo. Without this the jobs would inherit the
+# repository default token, which is write-scoped.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{env.GO_VERSION}}
 
@@ -77,8 +82,8 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{env.GO_VERSION}}
       - run: go fmt ./...

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,26 +5,31 @@ on:
       - master
       - feat/mk-docs
   workflow_dispatch:
-permissions: write-all
+# Restrictive default; each job widens only as far as it needs.
+permissions:
+  contents: read
 
 jobs:
   build:
     name: Build Docs
     runs-on: ubuntu-latest
+    # `mkdocs gh-deploy` pushes the built site to the gh-pages branch.
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure Git Credentials
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
@@ -45,20 +50,24 @@ jobs:
       name: smurf-url
       url: https://smurf.clouddrove.com
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           token: ${{ secrets.GITHUB }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         with:
-          artifact_name: github-pages	
+          artifact_name: github-pages

--- a/.github/workflows/publish-azure-devops-extension.yml
+++ b/.github/workflows/publish-azure-devops-extension.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate secret
         shell: bash
@@ -71,7 +71,7 @@ jobs:
           echo "path=azure-devops-extension/$vsix" >> "$GITHUB_OUTPUT"
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: smurf-azure-pipelines-vsix
           path: ${{ steps.vsix.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ env:
   APP_PACKAGE: github.com/clouddrove/smurf/cmd
   BINARY_NAME: smurf
 
+# Restrictive default; the jobs that need to write override it below.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
           - GOOS: windows
             ext: .exe
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
 
@@ -94,7 +98,7 @@ jobs:
         ls -la dist/
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: artifacts-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
         path: dist
@@ -108,7 +112,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
 
@@ -175,6 +179,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Build the docker image
     needs: build
+    # Pushes images to ghcr.io using GITHUB_TOKEN.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -184,7 +192,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download Linux Binary for Docker
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/test-multiplatform.yml
+++ b/.github/workflows/test-multiplatform.yml
@@ -3,6 +3,9 @@ on:
   # pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: 1.26.0
   TERRAFORM_VERSION: 1.15.2
@@ -19,7 +22,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Terraform on Windows
         if: matrix.os == 'windows-latest'
@@ -30,20 +33,20 @@ jobs:
 
       - name: Set up Terraform on Linux/macOS
         if: matrix.os != 'windows-latest'
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
       - name: Setup Docker on macOS
         if: matrix.os == 'macos-13'  
-        uses: douglascamata/setup-docker-macos-action@v1.1.0    
+        uses: douglascamata/setup-docker-macos-action@d5ccc6aae0ce23e7700154f5e63cc53e6433ac48 # v1.1.0
 
       - name: Set up QEMU on Linux/macOS
         if: matrix.os != 'windows-latest'
-        uses: docker/setup-qemu-action@v4      
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
        
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
Follow-up to #503, closing the two remaining CI gaps found while reviewing the dependabot queue.

## 1. Mutable action tags

Commit `603aacb` set a SHA-pinning policy but applied it only to `release.yml`. `build.yml`, `docs.yml`, `test-multiplatform.yml` and `publish-azure-devops-extension.yml` still referenced mutable tags, so an upstream retag would run new code in CI with nothing landing in this repo.

All ten remaining actions are now pinned to the commit behind their current latest stable release, annotated with the version:

| action | tag | pinned commit |
|---|---|---|
| actions/checkout | v7.0.1 | `3d3c42e` |
| actions/setup-go | v7.0.0 | `b7ad1da` |
| actions/setup-python | v7.0.0 | `5fda3b9` |
| actions/cache | v6.1.0 | `55cc834` |
| actions/upload-artifact | v7.0.1 | `043fb46` |
| actions/upload-pages-artifact | v5.0.0 | `fc324d3` |
| actions/deploy-pages | v5.0.0 | `cd2ce8f` |
| hashicorp/setup-terraform | v4.0.1 | `dfe3c3f` |
| douglascamata/setup-docker-macos-action | v1.1.0 | `d5ccc6a` |
| docker/setup-qemu-action | v4.2.0 | `96fe6ef` |

Every tag was resolved against the live API rather than assumed, and each SHA re-verified via `repos/<repo>/commits/<sha>`. The checkout, setup-go and upload-artifact SHAs match the pins `release.yml` already carried, which is a useful cross-check.

## 2. Over-broad workflow tokens

The repository default is `default_workflow_permissions: write` with `can_approve_pull_request_reviews: true`. Against that default:

- `docs.yml` declared `permissions: write-all`
- `build.yml`, `test-multiplatform.yml` and `release.yml` declared nothing, so every job inherited the write-scoped default

Each workflow now defaults to `contents: read`, with only the jobs that genuinely need more widening explicitly:

- **docs.yml `build`** → `contents: write` (`mkdocs gh-deploy` pushes to `gh-pages`)
- **docs.yml `deploy`** → `pages: write`, `id-token: write` (Pages deployment)
- **release.yml `docker-build`** → `packages: write` (pushes to `ghcr.io`)

`release.yml`'s `release` job already declared `contents: write` and is unchanged. `publish-azure-devops-extension.yml` already declared `contents: write`, which it needs to push the version bump, so it is unchanged too.

Worth noting the naive version of this change breaks the release: dropping a blanket `contents: read` on `release.yml` without the `docker-build` override would strip `packages: write` and fail the ghcr push. That job is only exercised on tag push, so it would not have shown up in PR CI.

## 3. Stray tab

`docs.yml` had a tab after `artifact_name: github-pages` that made the file fail a strict YAML parse. Removed; all six workflows now parse clean.

## Verification

All six workflows parse under `yaml.safe_load`. Every pinned SHA confirmed to resolve to a real commit in its repo.

## Not addressed

Upstream `clouddrove/github-shared-workflows` `pr-checks.yml:129` uses `wagoid/commitlint-github-action@v6`, a mutable tag. Our SHA pin of the reusable workflow freezes it transitively, so this is not exploitable here, but it is worth fixing at the source.