### PR TITLE
ci(security): build with Go 1.26.7 instead of 1.26.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 
 env:
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.7
   APP_PACKAGE: github.com/clouddrove/smurf/cmd 
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags: [ v* ]
 env:
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.7
   REPO: ${{ github.repository }}
   APP_PACKAGE: github.com/clouddrove/smurf/cmd
   BINARY_NAME: smurf

--- a/.github/workflows/test-multiplatform.yml
+++ b/.github/workflows/test-multiplatform.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.26.0
+  GO_VERSION: 1.26.7
   TERRAFORM_VERSION: 1.15.2
 
 jobs:


### PR DESCRIPTION
`build.yml`, `release.yml` and `test-multiplatform.yml` all pinned `GO_VERSION: 1.26.0`. Because `release.yml` uses the same pin, **published release binaries were compiled with a toolchain carrying known stdlib vulnerabilities**.

## Evidence

`govulncheck ./...` against master at Go 1.26.0 reports **23 vulnerabilities whose vulnerable symbols are actually reachable**. 21 are standard library: `crypto/x509`, `crypto/tls`, `net/http`, `net/url`, `net`, `os`, `archive/tar`, `encoding/asn1`, `encoding/xml`, `mime`, `net/textproto`. These are real call-graph traces, not module-level noise, e.g.:

```
internal/docker/build.go:135:23: docker.Build calls io.Copy,
  which eventually calls x509.Certificate.Verify
internal/helm/template.go:38:60: helm.HelmTemplate calls LocateChart,
  which calls url.Parse
```

A further 10 sat at package level (`html/template` XSS escaper bypasses, `os` root-escape via symlink, `net` CNAME crash), all fixed in 1.26.x too.

## Result

1.26.7 is the current 1.26 patch release (1.27.0 is also out; staying on the 1.26 line to keep this a patch-level change).

| | before (1.26.0) | after (1.26.7) |
|---|---|---|
| Symbol Results (reachable) | 23 | **2** |
| Package Results | 10 | **0** |
| Module Results | 8 | 6 |
| total | 41 | **8** |

The 2 remaining reachable findings are `GO-2026-4887` and `GO-2026-4883` in `github.com/docker/docker`, both `Fixed in: N/A`. Both are daemon-side (AuthZ plugin bypass, plugin privilege off-by-one) and not reachable from this codebase, which is a pure API client: it imports only `client`, `api/types*` and the `jsonmessage` struct, never `daemon/`, `builder/` or `pkg/archive`, and never creates or execs a container. Every one of their 43 traces is a package `init` or an ordinary client call like `ImageBuild`. That is the standard false-positive shape for module-scoped advisories with no symbol granularity in the Go vuln DB.

## Verification

Under Go 1.26.7: `go build ./...`, `go test ./...` and `go vet ./...` all pass.

## Notes

- The Dockerfile needs no change: `golang:1.26-alpine` already floats to the current patch.
- `go.mod` keeps `go 1.26.0` as the minimum language version. The fix comes from the compiling toolchain, not the directive, and raising it would force a newer Go on anyone building from source for no security benefit.
- Worth following up separately: wiring `govulncheck` into CI so a stale toolchain fails a check instead of going unnoticed. There is already an unmerged `hardening/govulncheck-coverage-utils-tests` branch that may cover this.