### PR TITLE
ci(security): restore govulncheck and lint workflows, gate on reachable vulns

### DIFF
--- a/.github/scripts/govulncheck_gate.py
+++ b/.github/scripts/govulncheck_gate.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fail the build on govulncheck findings whose vulnerable symbols are reachable.
+
+govulncheck reports at three levels of confidence. Only the strongest one,
+where a vulnerable *symbol* appears in the call graph, is treated as a gate.
+Findings where the module is merely required, or the package merely imported,
+are reported but do not fail: acting on those means chasing code that is never
+executed.
+
+Reads the concatenated-JSON stream produced by `govulncheck -format json`.
+Each finding looks like:
+
+    {"finding": {"osv": "GO-...", "trace": [{"module": ..., "package": ...,
+                                             "function": ...}]}}
+
+A trace whose first frame carries "function" is symbol-level.
+
+Exit codes: 0 clean or fully allowlisted, 1 gate failed, 2 bad input.
+"""
+
+import json
+import os
+import sys
+
+# Reachable findings that are accepted rather than fixed. Every entry needs a
+# reason and should be re-checked when the dependency is upgraded.
+#
+# GO-2026-4887  Moby AuthZ plugin bypass via oversized request bodies
+# GO-2026-4883  Moby off-by-one in plugin privilege validation
+#
+# Both are daemon-side. smurf is a pure Docker API client: it imports only
+# client, api/types* and the jsonmessage struct, never daemon/, builder/ or
+# pkg/archive, and never creates or execs a container. The Go vulnerability
+# database carries no symbol list for these advisories, so govulncheck treats
+# every symbol in the affected packages as vulnerable and every ordinary client
+# call (ImageBuild, ImagePush, ServerVersion) shows up as a trace. Neither has a
+# fixed version published, so there is nothing to upgrade to.
+ALLOWLIST = {
+    "GO-2026-4887",
+    "GO-2026-4883",
+}
+
+
+def parse_stream(text):
+    """Yield the objects in a concatenated-JSON document."""
+    decoder = json.JSONDecoder()
+    i, n = 0, len(text)
+    while i < n:
+        while i < n and text[i] in " \n\r\t":
+            i += 1
+        if i >= n:
+            return
+        obj, i = decoder.raw_decode(text, i)
+        yield obj
+
+
+def classify(findings):
+    """Map each OSV id to its strongest evidence level."""
+    rank = {"module": 0, "package": 1, "symbol": 2}
+    worst = {}
+    for finding in findings:
+        trace = finding.get("trace") or [{}]
+        frame = trace[0]
+        if frame.get("function"):
+            level = "symbol"
+        elif frame.get("package"):
+            level = "package"
+        else:
+            level = "module"
+        osv = finding.get("osv")
+        if osv and rank[level] > rank.get(worst.get(osv, "module"), -1):
+            worst[osv] = level
+    return worst
+
+
+def main():
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("govulncheck produced no output", file=sys.stderr)
+        return 2
+
+    try:
+        objects = list(parse_stream(raw))
+    except ValueError as exc:
+        print(f"could not parse govulncheck JSON: {exc}", file=sys.stderr)
+        return 2
+
+    findings = [o["finding"] for o in objects if "finding" in o]
+    summaries = {
+        o["osv"]["id"]: o["osv"].get("summary", "").strip()
+        for o in objects
+        if "osv" in o and "id" in o["osv"]
+    }
+
+    levels = classify(findings)
+    reachable = sorted(k for k, v in levels.items() if v == "symbol")
+    blocking = [k for k in reachable if k not in ALLOWLIST]
+    allowed = [k for k in reachable if k in ALLOWLIST]
+    lower = sorted(k for k, v in levels.items() if v != "symbol")
+
+    def describe(osv):
+        text = summaries.get(osv, "")
+        return f"{osv}  {text[:100]}" if text else osv
+
+    lines = ["### govulncheck", ""]
+    lines.append(
+        f"{len(blocking)} blocking, {len(allowed)} allowlisted, "
+        f"{len(lower)} lower-confidence"
+    )
+
+    if blocking:
+        lines += ["", "**Blocking (vulnerable symbol is reachable):**", ""]
+        lines += [f"- {describe(k)}" for k in blocking]
+    if allowed:
+        lines += ["", "Allowlisted (see .github/scripts/govulncheck_gate.py):", ""]
+        lines += [f"- {describe(k)}" for k in allowed]
+    if lower:
+        lines += ["", "Lower confidence (package imported or module required "
+                      "only, no reachable symbol):", ""]
+        lines += [f"- {describe(k)}" for k in lower]
+
+    report = "\n".join(lines)
+    print(report)
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as fh:
+            fh.write(report + "\n")
+
+    if blocking:
+        print(
+            f"\nFAIL: {len(blocking)} reachable vulnerabilit"
+            f"{'y' if len(blocking) == 1 else 'ies'} with no allowlist entry.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nOK: no unallowlisted reachable vulnerabilities.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -32,7 +32,16 @@ jobs:
       - name: Install govulncheck
         # Pinned rather than @latest so a scan result is reproducible and an
         # upstream release cannot change what this gate does without a commit.
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+        #
+        # SonarCloud S8545 wants a lock-file-enforcing install here. The Go
+        # mechanism for that is a go.mod tool directive, but `go get -tool`
+        # pulls x/vuln into the main module graph: it upgraded x/net, x/text
+        # and x/tools and left go.sum incomplete. The official
+        # golang/govulncheck-action is no better, since it runs
+        # `go install ...@latest` internally with no version input. An explicit
+        # version pin is the reproducible option that does not disturb the
+        # module graph, so the rule is suppressed rather than satisfied.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0 # NOSONAR
 
       # Human-readable report, always published even when the gate passes.
       - name: Report

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -30,7 +30,9 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # Pinned rather than @latest so a scan result is reproducible and an
+        # upstream release cannot change what this gate does without a commit.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       # Human-readable report, always published even when the gate passes.
       - name: Report

--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -1,0 +1,78 @@
+name: Go Security & Coverage
+
+# Vulnerability scanning (govulncheck) and unit-test coverage reporting.
+# The shared pr-checks workflow validates commit/PR conventions; this adds the
+# Go-specific safety net.
+#
+# This workflow and lint.yml were added in #461 and removed as collateral by
+# #469, an unrelated feature PR. Nothing noticed for six weeks, during which the
+# Go toolchain pin went stale and accumulated 21 reachable stdlib CVEs.
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: 1.26.7
+
+jobs:
+  govulncheck:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      # Human-readable report, always published even when the gate passes.
+      - name: Report
+        run: |
+          set -o pipefail
+          {
+            echo "<details><summary>Full govulncheck report</summary>"
+            echo
+            echo '```'
+            govulncheck ./... || true
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Gate: fails only when a vulnerable symbol is actually reachable and is
+      # not allowlisted. Module-only and package-only findings do not block.
+      - name: Gate on reachable vulnerabilities
+        run: |
+          set -o pipefail
+          govulncheck -format json ./... | python3 .github/scripts/govulncheck_gate.py
+
+  coverage:
+    name: Unit-test coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Test with coverage
+        # Unit packages only. The ./test/... integration suites need docker,
+        # helm and terraform binaries; make vet compile-checks them instead.
+        run: |
+          set -euo pipefail
+          PKGS=$(go list ./... | grep -v '/test/')
+          go test -covermode=atomic -coverprofile=coverage.out $PKGS
+          {
+            echo "### Unit-test coverage"
+            echo '```'
+            go tool cover -func=coverage.out | tail -1
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          go tool cover -func=coverage.out | tail -1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+# golangci-lint on PRs only, reporting only NEW issues (only-new-issues), so
+# the gate is non-disruptive on the existing codebase and tightens over time.
+# Config lives in .golangci.yml.
+#
+# Removed as collateral by #469 alongside go-security.yml, which left
+# .golangci.yml on master with no workflow reading it. Restored here.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.7"
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.13.1
+          only-new-issues: true


### PR DESCRIPTION
Restores two workflows that were silently deleted, and turns the vulnerability scan into a real gate.

## What happened

`go-security.yml` (govulncheck + coverage) and `lint.yml` (golangci-lint) were added in #461 on 2026-07-14. Four days later #469, titled `feat(stf): add --detailed-exitcode support to smurf stf plan`, deleted both:

```
.github/workflows/go-security.yml  |  64 ------------
.github/workflows/lint.yml         |  24 -----
```

Its commit messages read `fix: reverst workflows changes` twice, so this looks like collateral from resolving workflow conflicts rather than an intentional removal. Nothing noticed for six weeks.

Two consequences, both already observed:

1. The Go toolchain pin sat at 1.26.0 accumulating **21 reachable stdlib CVEs** until a manual scan caught it (#507). A working govulncheck job would have failed long before.
2. `.golangci.yml` has been on master this whole time with **no workflow reading it**.

## Restored, with changes

- `GO_VERSION` 1.26.0 → **1.26.7**, matching #507.
- All `uses:` SHA-pinned to the same commits as the rest of the repo (the originals pinned older checkout/setup-go SHAs, and setup-go v6).
- golangci-lint v2.12.2 → **v2.13.1**. `only-new-issues: true` retained, so legacy findings do not block.

## govulncheck is now a gate

The original step was deliberately informational, and its comment said why, and what to do about it:

> Informational, not a hard gate: [...] Failing every PR on an unfixable upstream vuln is noise. [...] tighten to a gate (with an allowlist for known-unfixable IDs) once the fixable set is clean.

After #507 the fixable set **is** clean, so this implements that plan.

`.github/scripts/govulncheck_gate.py` fails only when a vulnerable **symbol** is reachable in the call graph. govulncheck reports at three confidence levels; module-only and package-only findings are reported but never block, because acting on those means chasing code that never executes.

Two findings are allowlisted, each with its reasoning in the script:

| id | why |
|---|---|
| `GO-2026-4887` | Moby AuthZ plugin bypass. Daemon-side, `Fixed in: N/A`. |
| `GO-2026-4883` | Moby plugin privilege off-by-one. Daemon-side, `Fixed in: N/A`. |

Both are unreachable here: smurf is a pure Docker API client importing only `client`, `api/types*` and the `jsonmessage` struct, never `daemon/`, `builder/` or `pkg/archive`, and it never creates or execs a container. The Go vuln DB carries no symbol list for these advisories, so govulncheck treats every symbol in the affected packages as vulnerable and every ordinary call like `ImageBuild` shows up as a trace.

## Verification

The gate was tested against both toolchains, which is the case that matters — it must catch exactly the regression that went unnoticed:

| input | exit | result |
|---|---|---|
| scan under go1.26.0 | **1** | 21 blocking, correctly named |
| scan under go1.26.7 | **0** | 0 blocking, 2 allowlisted |
| empty stdin | 2 | guarded |
| malformed stdin | 2 | guarded |

The coverage job was re-run under bash: 11 packages, **10.6%** total. (`$PKGS` relies on word-splitting, which bash does and zsh does not; GitHub Actions `run:` is bash.)

A full human-readable `govulncheck` report is still written to the job summary on every run, gate pass or fail.

## Follow-up worth considering

Nothing prevents a repeat of #469. A CODEOWNERS entry on `.github/workflows/` would require review before workflow deletions land.